### PR TITLE
FIX : replace hardcoded nav with auth-aware Navbar on public pages

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,89 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+/**
+ * Presentation Layer – Shared auth-aware navigation bar.
+ * Shows login/register links for guests and a welcome message,
+ * dashboard link, and logout button for authenticated users.
+ * Used by LandingPage and ProductListingPage (public pages that
+ * need to reflect session state without being protected routes).
+ */
+
+/** Maps each backend role to its dashboard route. */
+const ROLE_DASHBOARD = {
+  CUSTOMER: '/dashboard',
+  ADMIN: '/admin',
+  SUPPLIER: '/supplier',
+  DELIVERY: '/delivery',
+};
+
+/**
+ * Renders the top navigation bar.
+ * Reads auth state from AuthContext so it always reflects the
+ * live session — no prop drilling required.
+ */
+export default function Navbar() {
+  const { isAuthenticated, user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/', { replace: true });
+  };
+
+  const dashboardPath = ROLE_DASHBOARD[user?.role] || '/';
+
+  return (
+    <nav className="bg-white shadow-sm sticky top-0 z-10">
+      <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+        {/* Logo */}
+        <Link to="/" className="text-2xl font-bold text-green-600 tracking-tight">
+          UrbanFresh
+        </Link>
+
+        {isAuthenticated ? (
+          /* ── Authenticated state ── */
+          <div className="flex items-center gap-3">
+            {/* Friendly welcome badge */}
+            <span className="hidden sm:flex items-center gap-1.5 text-sm text-gray-600 font-medium">
+              <span className="inline-flex items-center justify-center w-5 h-5 bg-green-100 rounded-full text-green-600 text-xs">✓</span>
+              Welcome back, {user?.name}!
+            </span>
+
+            {/* Dashboard shortcut */}
+            <Link
+              to={dashboardPath}
+              className="px-4 py-2 text-sm font-medium text-green-700 border border-green-600 rounded-lg hover:bg-green-50 transition-colors"
+            >
+              My Dashboard
+            </Link>
+
+            {/* Logout */}
+            <button
+              onClick={handleLogout}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-500 rounded-lg hover:bg-red-600 transition-colors"
+            >
+              Log Out
+            </button>
+          </div>
+        ) : (
+          /* ── Guest state ── */
+          <div className="flex gap-3">
+            <Link
+              to="/login"
+              className="px-4 py-2 text-sm font-medium text-green-700 border border-green-600 rounded-lg hover:bg-green-50 transition-colors"
+            >
+              Log In
+            </Link>
+            <Link
+              to="/register"
+              className="px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors"
+            >
+              Register
+            </Link>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/pages/landing/LandingPage.jsx
+++ b/frontend/src/pages/landing/LandingPage.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getFeaturedProducts, getNearExpiryProducts } from '../../services/productService';
+import Navbar from '../../components/Navbar';
+import { useAuth } from '../../context/AuthContext';
 
 /**
  * Page Layer – Public landing page for UrbanFresh.
@@ -8,6 +10,7 @@ import { getFeaturedProducts, getNearExpiryProducts } from '../../services/produ
  * Accessible without authentication; shows login/register links in the nav.
  */
 export default function LandingPage() {
+  const { isAuthenticated, user } = useAuth();
   const [featured, setFeatured] = useState([]);
   const [nearExpiry, setNearExpiry] = useState([]);
   const [loadingFeatured, setLoadingFeatured] = useState(true);
@@ -28,30 +31,14 @@ export default function LandingPage() {
       .finally(() => setLoadingNearExpiry(false));
   }, []);
 
+  // Derive the dashboard path so the hero CTA sends authenticated
+  // users directly to their role-specific dashboard
+  const heroDashboard = { CUSTOMER: '/dashboard', ADMIN: '/admin', SUPPLIER: '/supplier', DELIVERY: '/delivery' }[user?.role] || '/dashboard';
+
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* ── Navigation ── */}
-      <nav className="bg-white shadow-sm sticky top-0 z-10">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link to="/" className="text-2xl font-bold text-green-600 tracking-tight">
-            UrbanFresh
-          </Link>
-          <div className="flex gap-3">
-            <Link
-              to="/login"
-              className="px-4 py-2 text-sm font-medium text-green-700 border border-green-600 rounded-lg hover:bg-green-50 transition-colors"
-            >
-              Log In
-            </Link>
-            <Link
-              to="/register"
-              className="px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors"
-            >
-              Register
-            </Link>
-          </div>
-        </div>
-      </nav>
+      {/* ── Navigation (auth-aware via shared Navbar) ── */}
+      <Navbar />
 
       {/* ── Hero ── */}
       <section className="bg-green-600 text-white py-20 px-4 text-center">
@@ -63,18 +50,39 @@ export default function LandingPage() {
           and the planet.
         </p>
         <div className="flex gap-4 justify-center flex-wrap">
-          <Link
-            to="/register"
-            className="px-6 py-3 bg-white text-green-700 font-semibold rounded-lg hover:bg-green-50 transition-colors"
-          >
-            Get Started
-          </Link>
-          <Link
-            to="/login"
-            className="px-6 py-3 border border-white text-white font-semibold rounded-lg hover:bg-green-700 transition-colors"
-          >
-            Log In
-          </Link>
+          {isAuthenticated ? (
+            /* Authenticated hero CTAs — skip sign-in prompts */
+            <>
+              <Link
+                to="/products"
+                className="px-6 py-3 bg-white text-green-700 font-semibold rounded-lg hover:bg-green-50 transition-colors"
+              >
+                Browse Products
+              </Link>
+              <Link
+                to={heroDashboard}
+                className="px-6 py-3 border border-white text-white font-semibold rounded-lg hover:bg-green-700 transition-colors"
+              >
+                My Dashboard
+              </Link>
+            </>
+          ) : (
+            /* Guest hero CTAs */
+            <>
+              <Link
+                to="/register"
+                className="px-6 py-3 bg-white text-green-700 font-semibold rounded-lg hover:bg-green-50 transition-colors"
+              >
+                Get Started
+              </Link>
+              <Link
+                to="/login"
+                className="px-6 py-3 border border-white text-white font-semibold rounded-lg hover:bg-green-700 transition-colors"
+              >
+                Log In
+              </Link>
+            </>
+          )}
         </div>
       </section>
 

--- a/frontend/src/pages/products/ProductListingPage.jsx
+++ b/frontend/src/pages/products/ProductListingPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { getProducts, getCategories } from '../../services/productService';
+import Navbar from '../../components/Navbar';
 
 /**
  * Page Layer – Public product listing page.
@@ -70,28 +71,8 @@ export default function ProductListingPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* ── Navigation ── */}
-      <nav className="bg-white shadow-sm sticky top-0 z-10">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link to="/" className="text-2xl font-bold text-green-600 tracking-tight">
-            UrbanFresh
-          </Link>
-          <div className="flex gap-3">
-            <Link
-              to="/login"
-              className="px-4 py-2 text-sm font-medium text-green-700 border border-green-600 rounded-lg hover:bg-green-50 transition-colors"
-            >
-              Log In
-            </Link>
-            <Link
-              to="/register"
-              className="px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 transition-colors"
-            >
-              Register
-            </Link>
-          </div>
-        </div>
-      </nav>
+      {/* ── Navigation (auth-aware via shared Navbar) ── */}
+      <Navbar />
 
       <div className="max-w-6xl mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold text-gray-800 mb-6">All Products</h1>


### PR DESCRIPTION
LandingPage and ProductListingPage were rendered after SCRUM-6 was
done but never consumed AuthContext. Both pages always showed
Log In / Register regardless of session state.

- Extract shared Navbar component (src/components/Navbar.jsx) that
  reads isAuthenticated, user, and logout from AuthContext
- Show "Welcome back, {name}" + My Dashboard + Log Out when logged in
- Show Log In + Register for guests
- Update LandingPage hero CTAs to reflect auth state
- Removes duplicated nav markup — DRY across both public pages

Fixes: session state not visible after SCRUM-6 implementation