### PR TITLE
SCRUM-29: Admin Creates Supplier Account + Assigns Brand

### DIFF
--- a/backend/src/main/java/com/urbanfresh/controller/AdminController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/AdminController.java
@@ -30,10 +30,14 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.urbanfresh.dto.request.OrderStatusUpdateRequest;
 import com.urbanfresh.dto.request.ProductRequest;
+import com.urbanfresh.dto.request.CreateSupplierRequest;
+import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
 import com.urbanfresh.dto.response.AdminOrderResponse;
 import com.urbanfresh.dto.response.AdminOrderReviewResponse;
 import com.urbanfresh.dto.response.AdminProductResponse;
 import com.urbanfresh.dto.response.AdminStatsResponse;
+import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierResponse;
 import com.urbanfresh.service.AdminProductService;
 import com.urbanfresh.service.AdminService;
 import com.urbanfresh.service.OrderService;
@@ -253,6 +257,58 @@ public class AdminController {
             @Valid @RequestBody com.urbanfresh.dto.request.UpdateDeliveryPersonnelStatusRequest request) {
         var response = adminService.updateDeliveryPersonnelStatus(deliveryPersonnelId, request);
         return ResponseEntity.ok(response);
+    }
+
+    // ── Supplier Management ────────────────────────────────────────────────
+
+    /**
+     * Create a new supplier account with one or more assigned brands.
+     * POST /api/admin/suppliers
+     *
+     * @param request validated supplier creation payload
+     * @return 201 Created with SupplierResponse
+     */
+    @PostMapping("/suppliers")
+    public ResponseEntity<SupplierResponse> createSupplier(@Valid @RequestBody CreateSupplierRequest request) {
+        SupplierResponse response = adminService.createSupplier(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Retrieve all suppliers for admin management.
+     * GET /api/admin/suppliers
+     *
+     * @return 200 OK with list of SupplierResponse
+     */
+    @GetMapping("/suppliers")
+    public ResponseEntity<List<SupplierResponse>> getSuppliers() {
+        return ResponseEntity.ok(adminService.getSuppliers());
+    }
+
+    /**
+     * Activate or deactivate supplier access.
+     * PATCH /api/admin/suppliers/{id}/status
+     *
+     * @param supplierId supplier user ID
+     * @param request activation payload
+     * @return 200 OK with updated SupplierResponse
+     */
+    @PatchMapping("/suppliers/{id}/status")
+    public ResponseEntity<SupplierResponse> updateSupplierStatus(
+            @PathVariable("id") Long supplierId,
+            @Valid @RequestBody UpdateSupplierStatusRequest request) {
+        return ResponseEntity.ok(adminService.updateSupplierStatus(supplierId, request));
+    }
+
+    /**
+     * Returns active brands for supplier assignment forms.
+     * GET /api/admin/brands
+     *
+     * @return 200 OK with list of active brands
+     */
+    @GetMapping("/brands")
+    public ResponseEntity<List<BrandResponse>> getActiveBrands() {
+        return ResponseEntity.ok(adminService.getActiveBrands());
     }
 
     /**

--- a/backend/src/main/java/com/urbanfresh/controller/AdminController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/AdminController.java
@@ -28,9 +28,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.urbanfresh.dto.request.BrandRequest;
+import com.urbanfresh.dto.request.CreateSupplierRequest;
 import com.urbanfresh.dto.request.OrderStatusUpdateRequest;
 import com.urbanfresh.dto.request.ProductRequest;
-import com.urbanfresh.dto.request.CreateSupplierRequest;
+import com.urbanfresh.dto.request.UpdateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
 import com.urbanfresh.dto.response.AdminOrderResponse;
 import com.urbanfresh.dto.response.AdminOrderReviewResponse;
@@ -301,6 +303,21 @@ public class AdminController {
     }
 
     /**
+     * Update supplier profile and assigned brands.
+     * PUT /api/admin/suppliers/{id}
+     *
+     * @param supplierId supplier user ID
+     * @param request validated update payload
+     * @return 200 OK with updated SupplierResponse
+     */
+    @PutMapping("/suppliers/{id}")
+    public ResponseEntity<SupplierResponse> updateSupplier(
+            @PathVariable("id") Long supplierId,
+            @Valid @RequestBody UpdateSupplierRequest request) {
+        return ResponseEntity.ok(adminService.updateSupplier(supplierId, request));
+    }
+
+    /**
      * Returns active brands for supplier assignment forms.
      * GET /api/admin/brands
      *
@@ -309,6 +326,58 @@ public class AdminController {
     @GetMapping("/brands")
     public ResponseEntity<List<BrandResponse>> getActiveBrands() {
         return ResponseEntity.ok(adminService.getActiveBrands());
+    }
+
+    /**
+     * Returns all brands for admin brand management.
+     * GET /api/admin/brands/all
+     *
+     * @return 200 OK with all brands list
+     */
+    @GetMapping("/brands/all")
+    public ResponseEntity<List<BrandResponse>> getAllBrands() {
+        return ResponseEntity.ok(adminService.getAllBrands());
+    }
+
+    /**
+     * Create a new brand.
+     * POST /api/admin/brands
+     *
+     * @param request validated brand payload
+     * @return 201 Created with BrandResponse
+     */
+    @PostMapping("/brands")
+    public ResponseEntity<BrandResponse> createBrand(@Valid @RequestBody BrandRequest request) {
+        BrandResponse response = adminService.createBrand(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Update an existing brand.
+     * PUT /api/admin/brands/{id}
+     *
+     * @param brandId brand ID
+     * @param request validated brand payload
+     * @return 200 OK with updated BrandResponse
+     */
+    @PutMapping("/brands/{id}")
+    public ResponseEntity<BrandResponse> updateBrand(
+            @PathVariable("id") Long brandId,
+            @Valid @RequestBody BrandRequest request) {
+        return ResponseEntity.ok(adminService.updateBrand(brandId, request));
+    }
+
+    /**
+     * Soft delete a brand by deactivation.
+     * DELETE /api/admin/brands/{id}
+     *
+     * @param brandId brand ID
+     * @return 204 No Content
+     */
+    @DeleteMapping("/brands/{id}")
+    public ResponseEntity<Void> deleteBrand(@PathVariable("id") Long brandId) {
+        adminService.deleteBrand(brandId);
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/backend/src/main/java/com/urbanfresh/controller/SupplierController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/SupplierController.java
@@ -1,0 +1,50 @@
+package com.urbanfresh.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierProductResponse;
+import com.urbanfresh.service.SupplierService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Controller Layer – Supplier-only endpoints for scoped dashboard data.
+ */
+@RestController
+@RequestMapping("/api/supplier")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('SUPPLIER')")
+public class SupplierController {
+
+    private final SupplierService supplierService;
+
+    /**
+     * Returns brands assigned to the authenticated supplier.
+     *
+     * @param authentication authenticated supplier principal
+     * @return assigned brands list
+     */
+    @GetMapping("/brands")
+    public ResponseEntity<List<BrandResponse>> getAssignedBrands(Authentication authentication) {
+        return ResponseEntity.ok(supplierService.getAssignedBrands(authentication.getName()));
+    }
+
+    /**
+     * Returns products scoped to the authenticated supplier's assigned brands.
+     *
+     * @param authentication authenticated supplier principal
+     * @return supplier product list
+     */
+    @GetMapping("/products")
+    public ResponseEntity<List<SupplierProductResponse>> getSupplierProducts(Authentication authentication) {
+        return ResponseEntity.ok(supplierService.getSupplierProducts(authentication.getName()));
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/dto/request/BrandRequest.java
+++ b/backend/src/main/java/com/urbanfresh/dto/request/BrandRequest.java
@@ -1,0 +1,26 @@
+package com.urbanfresh.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO Layer – Validated payload for admin brand create and update operations.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandRequest {
+
+    @NotBlank(message = "Brand name is required")
+    @Size(max = 120, message = "Brand name must not exceed 120 characters")
+    private String name;
+
+    @NotBlank(message = "Brand code is required")
+    @Size(max = 60, message = "Brand code must not exceed 60 characters")
+    private String code;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/request/CreateSupplierRequest.java
+++ b/backend/src/main/java/com/urbanfresh/dto/request/CreateSupplierRequest.java
@@ -1,0 +1,47 @@
+package com.urbanfresh.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO Layer – Validated payload for creating supplier accounts.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSupplierRequest {
+
+    @NotBlank(message = "Name is required")
+    @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
+    private String name;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be a valid format")
+    @Size(max = 150, message = "Email must not exceed 150 characters")
+    private String email;
+
+    @NotBlank(message = "Temporary password is required")
+    @Size(min = 8, max = 64, message = "Password must be between 8 and 64 characters")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$",
+            message = "Password must contain at least one uppercase letter, one lowercase letter, one digit, and one special character"
+    )
+    private String password;
+
+    @Pattern(regexp = "^$|^\\d{10,15}$", message = "Phone must be 10–15 digits")
+    private String phone;
+
+    @NotEmpty(message = "At least one brand must be assigned")
+    private List<@NotNull(message = "Brand ID cannot be null") Long> brandIds;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/request/ProductRequest.java
+++ b/backend/src/main/java/com/urbanfresh/dto/request/ProductRequest.java
@@ -4,10 +4,12 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import com.urbanfresh.model.PricingUnit;
+
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,6 +39,10 @@ public class ProductRequest {
 
     @Size(max = 500, message = "Image URL must not exceed 500 characters")
     private String imageUrl;
+
+    /** Optional brand association. Null means unbranded product. */
+    @Positive(message = "Brand ID must be a positive number")
+    private Long brandId;
 
     /** Whether this product is promoted in the landing page featured section. */
     private boolean featured;

--- a/backend/src/main/java/com/urbanfresh/dto/request/UpdateSupplierRequest.java
+++ b/backend/src/main/java/com/urbanfresh/dto/request/UpdateSupplierRequest.java
@@ -1,0 +1,33 @@
+package com.urbanfresh.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO Layer – Validated payload for updating supplier profile and brand assignments.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateSupplierRequest {
+
+    @NotBlank(message = "Name is required")
+    @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
+    private String name;
+
+    @Pattern(regexp = "^$|^\\d{10,15}$", message = "Phone must be 10–15 digits")
+    private String phone;
+
+    @NotEmpty(message = "At least one brand must be assigned")
+    private List<@NotNull(message = "Brand ID cannot be null") Long> brandIds;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/request/UpdateSupplierStatusRequest.java
+++ b/backend/src/main/java/com/urbanfresh/dto/request/UpdateSupplierStatusRequest.java
@@ -1,0 +1,20 @@
+package com.urbanfresh.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO Layer – Payload for toggling supplier account activation.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateSupplierStatusRequest {
+
+    @NotNull(message = "isActive is required")
+    private Boolean isActive;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/AdminProductResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/AdminProductResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.urbanfresh.model.PricingUnit;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +30,9 @@ public class AdminProductResponse {
     private BigDecimal price;
     private PricingUnit unit;
     private String category;
+    private Long brandId;
+    private String brandName;
+    private String brandCode;
     private String imageUrl;
     private boolean featured;
     private LocalDate expiryDate;

--- a/backend/src/main/java/com/urbanfresh/dto/response/BrandResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/BrandResponse.java
@@ -1,0 +1,16 @@
+package com.urbanfresh.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * DTO Layer – Lightweight brand payload for assignment and supplier views.
+ */
+@Getter
+@Builder
+public class BrandResponse {
+
+    private Long id;
+    private String name;
+    private String code;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/BrandResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/BrandResponse.java
@@ -13,4 +13,5 @@ public class BrandResponse {
     private Long id;
     private String name;
     private String code;
+    private Boolean active;
 }

--- a/backend/src/main/java/com/urbanfresh/dto/response/SupplierProductResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/SupplierProductResponse.java
@@ -1,0 +1,24 @@
+package com.urbanfresh.dto.response;
+
+import java.math.BigDecimal;
+
+import com.urbanfresh.model.PricingUnit;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * DTO Layer – Product payload exposed to supplier dashboards.
+ */
+@Getter
+@Builder
+public class SupplierProductResponse {
+
+    private Long id;
+    private String name;
+    private String category;
+    private String brandName;
+    private BigDecimal price;
+    private PricingUnit unit;
+    private Integer stockQuantity;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/SupplierResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/SupplierResponse.java
@@ -1,0 +1,23 @@
+package com.urbanfresh.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * DTO Layer – Supplier account payload for admin management screens.
+ */
+@Getter
+@Builder
+public class SupplierResponse {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String phone;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private List<BrandResponse> brands;
+}

--- a/backend/src/main/java/com/urbanfresh/exception/BrandAssignmentException.java
+++ b/backend/src/main/java/com/urbanfresh/exception/BrandAssignmentException.java
@@ -1,0 +1,11 @@
+package com.urbanfresh.exception;
+
+/**
+ * Exception Layer – Raised when supplier-brand assignments are invalid.
+ */
+public class BrandAssignmentException extends RuntimeException {
+
+    public BrandAssignmentException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/exception/BrandConflictException.java
+++ b/backend/src/main/java/com/urbanfresh/exception/BrandConflictException.java
@@ -1,0 +1,11 @@
+package com.urbanfresh.exception;
+
+/**
+ * Exception Layer – Raised when a brand unique field conflicts with an existing brand.
+ */
+public class BrandConflictException extends RuntimeException {
+
+    public BrandConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/exception/BrandNotFoundException.java
+++ b/backend/src/main/java/com/urbanfresh/exception/BrandNotFoundException.java
@@ -1,0 +1,11 @@
+package com.urbanfresh.exception;
+
+/**
+ * Exception Layer – Raised when a requested brand does not exist.
+ */
+public class BrandNotFoundException extends RuntimeException {
+
+    public BrandNotFoundException(Long brandId) {
+        super("Brand not found with ID: " + brandId);
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/exception/DuplicateEmailException.java
+++ b/backend/src/main/java/com/urbanfresh/exception/DuplicateEmailException.java
@@ -7,6 +7,6 @@ package com.urbanfresh.exception;
 public class DuplicateEmailException extends RuntimeException {
 
     public DuplicateEmailException(String email) {
-        super("Email already registered: " + email);
+        super("This email is already registered.");
     }
 }

--- a/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
@@ -96,6 +96,34 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handle brand uniqueness conflicts -> 409 Conflict.
+     */
+    @ExceptionHandler(BrandConflictException.class)
+    public ResponseEntity<ApiErrorResponse> handleBrandConflict(BrandConflictException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.CONFLICT.value())
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    /**
+     * Handle brand not found -> 404 Not Found.
+     */
+    @ExceptionHandler(BrandNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleBrandNotFound(BrandNotFoundException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    /**
      * Handle user not found → 404 Not Found.
      */
     @ExceptionHandler(UserNotFoundException.class)

--- a/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
@@ -68,6 +68,34 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handle deactivated supplier login attempts → 403 Forbidden.
+     */
+    @ExceptionHandler(SupplierInactiveException.class)
+    public ResponseEntity<ApiErrorResponse> handleSupplierInactive(SupplierInactiveException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.FORBIDDEN.value())
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    /**
+     * Handle invalid supplier-brand assignment payloads → 400 Bad Request.
+     */
+    @ExceptionHandler(BrandAssignmentException.class)
+    public ResponseEntity<ApiErrorResponse> handleBrandAssignment(BrandAssignmentException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
      * Handle user not found → 404 Not Found.
      */
     @ExceptionHandler(UserNotFoundException.class)

--- a/backend/src/main/java/com/urbanfresh/exception/SupplierInactiveException.java
+++ b/backend/src/main/java/com/urbanfresh/exception/SupplierInactiveException.java
@@ -1,0 +1,11 @@
+package com.urbanfresh.exception;
+
+/**
+ * Exception Layer – Raised when an inactive supplier attempts to authenticate.
+ */
+public class SupplierInactiveException extends RuntimeException {
+
+    public SupplierInactiveException() {
+        super("Supplier account is inactive. Please contact an administrator.");
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/model/Brand.java
+++ b/backend/src/main/java/com/urbanfresh/model/Brand.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,61 +17,45 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * Domain Layer – JPA entity representing a platform user.
- * Stores credentials, role, and contact info.
- * Maps to the "users" table in MySQL.
+ * Domain Layer – JPA entity representing a supplier brand.
+ * Used to scope supplier product visibility and ownership.
  */
 @Entity
-@Table(name = "users")
+@Table(name = "brands")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User {
+public class Brand {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, unique = true, length = 120)
     private String name;
 
-    @Column(nullable = false, unique = true, length = 150)
-    private String email;
+    @Column(nullable = false, unique = true, length = 60)
+    private String code;
 
     @Column(nullable = false)
-    private String password;
-
-    @Column(length = 15)
-    private String phone;
-
-    // Delivery address kept on the user record to pre-fill checkout and reduce re-entry
-    @Column(length = 300)
-    private String address;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private Role role;
-
-    /** Account activation status. False means the user cannot log in. Defaults to true. */
-    @Column(name = "active", nullable = false)
     @Builder.Default
-    private Boolean isActive = true;
+    private Boolean active = true;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
-    /** Set timestamps automatically before first persist. */
+    /** Set timestamps before first persist. */
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
-    /** Update timestamp automatically before each update. */
+    /** Refresh update timestamp before each update. */
     @PreUpdate
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();

--- a/backend/src/main/java/com/urbanfresh/model/Product.java
+++ b/backend/src/main/java/com/urbanfresh/model/Product.java
@@ -8,9 +8,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -51,6 +54,10 @@ public class Product {
 
     @Column(length = 80)
     private String category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id")
+    private Brand brand;
 
     /** URL to the product image (CDN path or relative asset path). */
     @Column(length = 500)

--- a/backend/src/main/java/com/urbanfresh/model/SupplierBrand.java
+++ b/backend/src/main/java/com/urbanfresh/model/SupplierBrand.java
@@ -1,0 +1,41 @@
+package com.urbanfresh.model;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Domain Layer – Join entity between supplier users and brands.
+ * Encodes many-to-many ownership mapping for RBAC scoping.
+ */
+@Entity
+@Table(name = "supplier_brands")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SupplierBrand {
+
+    @EmbeddedId
+    private SupplierBrandId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("supplierId")
+    @JoinColumn(name = "supplier_id", nullable = false)
+    private User supplier;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("brandId")
+    @JoinColumn(name = "brand_id", nullable = false)
+    private Brand brand;
+}

--- a/backend/src/main/java/com/urbanfresh/model/SupplierBrandId.java
+++ b/backend/src/main/java/com/urbanfresh/model/SupplierBrandId.java
@@ -1,0 +1,30 @@
+package com.urbanfresh.model;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Domain Layer – Composite key for supplier-brand mappings.
+ * Keys are supplier_id and brand_id.
+ */
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class SupplierBrandId implements Serializable {
+
+    @Column(name = "supplier_id")
+    private Long supplierId;
+
+    @Column(name = "brand_id")
+    private Long brandId;
+}

--- a/backend/src/main/java/com/urbanfresh/repository/BrandRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/BrandRepository.java
@@ -1,0 +1,22 @@
+package com.urbanfresh.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.urbanfresh.model.Brand;
+
+/**
+ * Repository Layer – Data access for Brand entities.
+ */
+@Repository
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+
+    /**
+     * Returns active brands ordered by name for assignment UIs.
+     *
+     * @return list of active brands
+     */
+    List<Brand> findByActiveTrueOrderByNameAsc();
+}

--- a/backend/src/main/java/com/urbanfresh/repository/BrandRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/BrandRepository.java
@@ -19,4 +19,45 @@ public interface BrandRepository extends JpaRepository<Brand, Long> {
      * @return list of active brands
      */
     List<Brand> findByActiveTrueOrderByNameAsc();
+
+    /**
+     * Returns all brands ordered by name for admin brand management.
+     *
+     * @return list of all brands
+     */
+    List<Brand> findAllByOrderByNameAsc();
+
+    /**
+     * Check whether a brand name already exists (case-insensitive).
+     *
+     * @param name brand name
+     * @return true if taken
+     */
+    boolean existsByNameIgnoreCase(String name);
+
+    /**
+     * Check whether a brand code already exists (case-insensitive).
+     *
+     * @param code brand code
+     * @return true if taken
+     */
+    boolean existsByCodeIgnoreCase(String code);
+
+    /**
+     * Check name uniqueness excluding current brand during updates.
+     *
+     * @param name brand name
+     * @param id current brand ID
+     * @return true if conflicting
+     */
+    boolean existsByNameIgnoreCaseAndIdNot(String name, Long id);
+
+    /**
+     * Check code uniqueness excluding current brand during updates.
+     *
+     * @param code brand code
+     * @param id current brand ID
+     * @return true if conflicting
+     */
+    boolean existsByCodeIgnoreCaseAndIdNot(String code, Long id);
 }

--- a/backend/src/main/java/com/urbanfresh/repository/ProductRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/ProductRepository.java
@@ -104,4 +104,18 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             LocalDate cutoff,
             int minStock
     );
+
+    /**
+     * Returns products visible to a supplier based on assigned brands.
+     *
+     * @param supplierId authenticated supplier user ID
+     * @return list of products owned by assigned active brands
+     */
+    @Query("SELECT DISTINCT p FROM Product p " +
+            "JOIN p.brand b " +
+            "JOIN SupplierBrand sb ON sb.brand.id = b.id " +
+            "WHERE sb.supplier.id = :supplierId " +
+            "AND b.active = true " +
+            "ORDER BY p.name ASC")
+    List<Product> findProductsForSupplier(@Param("supplierId") Long supplierId);
 }

--- a/backend/src/main/java/com/urbanfresh/repository/SupplierBrandRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/SupplierBrandRepository.java
@@ -1,0 +1,38 @@
+package com.urbanfresh.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.urbanfresh.model.SupplierBrand;
+import com.urbanfresh.model.SupplierBrandId;
+
+/**
+ * Repository Layer – Data access for supplier-brand mappings.
+ */
+@Repository
+public interface SupplierBrandRepository extends JpaRepository<SupplierBrand, SupplierBrandId> {
+
+    /**
+     * Load all mappings for a supplier.
+     *
+     * @param supplierId supplier user ID
+     * @return mapping rows
+     */
+    @Query("SELECT sb FROM SupplierBrand sb JOIN FETCH sb.brand WHERE sb.supplier.id = :supplierId ORDER BY sb.brand.name ASC")
+    List<SupplierBrand> findBySupplierId(@Param("supplierId") Long supplierId);
+
+    /**
+     * Delete all mappings for a supplier.
+     * Used when replacing assignments.
+     *
+     * @param supplierId supplier user ID
+     */
+    @Modifying
+    @Query("DELETE FROM SupplierBrand sb WHERE sb.supplier.id = :supplierId")
+    void deleteBySupplierId(@Param("supplierId") Long supplierId);
+}

--- a/backend/src/main/java/com/urbanfresh/repository/UserRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.urbanfresh.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -26,6 +27,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     /** Find all delivery personnel (active and inactive). Page-aware query. */
     Page<User> findByRole(Role role, Pageable pageable);
 
+    /** Find users by role sorted by name for admin listing screens. */
+    List<User> findByRoleOrderByNameAsc(Role role);
+
+    /** Find a user by ID and role (used to guard supplier-only operations). */
+    Optional<User> findByIdAndRole(Long id, Role role);
+
+    /** Find an active user by email and role (used for supplier scope checks). */
+    Optional<User> findByEmailAndRoleAndIsActiveTrue(String email, Role role);
+
     /** Count all users with a specific role. */
     int countByRole(Role role);
+
+    /** Count active users by role. */
+    int countByRoleAndIsActiveTrue(Role role);
 }

--- a/backend/src/main/java/com/urbanfresh/service/AdminService.java
+++ b/backend/src/main/java/com/urbanfresh/service/AdminService.java
@@ -1,12 +1,18 @@
 package com.urbanfresh.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.urbanfresh.dto.request.CreateDeliveryPersonnelRequest;
+import com.urbanfresh.dto.request.CreateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateDeliveryPersonnelStatusRequest;
+import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
 import com.urbanfresh.dto.response.AdminStatsResponse;
+import com.urbanfresh.dto.response.BrandResponse;
 import com.urbanfresh.dto.response.DeliveryPersonnelResponse;
+import com.urbanfresh.dto.response.SupplierResponse;
 
 /**
  * Service Layer – Defines admin-specific business operations.
@@ -50,4 +56,35 @@ public interface AdminService {
      * @throws com.urbanfresh.exception.UserNotFoundException if delivery personnel not found
      */
     DeliveryPersonnelResponse updateDeliveryPersonnelStatus(Long deliveryPersonnelId, UpdateDeliveryPersonnelStatusRequest request);
+
+    /**
+     * Create a new supplier account and assign one or more brands.
+     *
+     * @param request validated supplier creation payload
+     * @return created supplier account and assigned brands
+     */
+    SupplierResponse createSupplier(CreateSupplierRequest request);
+
+    /**
+     * Retrieve all supplier accounts (sorted by name) for admin management.
+     *
+     * @return list of suppliers with assigned brands
+     */
+    List<SupplierResponse> getSuppliers();
+
+    /**
+     * Activate or deactivate a supplier account.
+     *
+     * @param supplierId supplier account ID
+     * @param request activation payload
+     * @return updated supplier response
+     */
+    SupplierResponse updateSupplierStatus(Long supplierId, UpdateSupplierStatusRequest request);
+
+    /**
+     * Retrieve assignable active brands for admin forms.
+     *
+     * @return list of active brands
+     */
+    List<BrandResponse> getActiveBrands();
 }

--- a/backend/src/main/java/com/urbanfresh/service/AdminService.java
+++ b/backend/src/main/java/com/urbanfresh/service/AdminService.java
@@ -5,9 +5,11 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.urbanfresh.dto.request.BrandRequest;
 import com.urbanfresh.dto.request.CreateDeliveryPersonnelRequest;
 import com.urbanfresh.dto.request.CreateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateDeliveryPersonnelStatusRequest;
+import com.urbanfresh.dto.request.UpdateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
 import com.urbanfresh.dto.response.AdminStatsResponse;
 import com.urbanfresh.dto.response.BrandResponse;
@@ -82,9 +84,49 @@ public interface AdminService {
     SupplierResponse updateSupplierStatus(Long supplierId, UpdateSupplierStatusRequest request);
 
     /**
+     * Update supplier profile details and assigned brands.
+     *
+     * @param supplierId supplier account ID
+     * @param request validated update payload
+     * @return updated supplier account and assigned brands
+     */
+    SupplierResponse updateSupplier(Long supplierId, UpdateSupplierRequest request);
+
+    /**
      * Retrieve assignable active brands for admin forms.
      *
      * @return list of active brands
      */
     List<BrandResponse> getActiveBrands();
+
+    /**
+     * Retrieve all brands for brand management.
+     *
+     * @return list of all brands sorted by name
+     */
+    List<BrandResponse> getAllBrands();
+
+    /**
+     * Create a new brand for supplier and product assignment.
+     *
+     * @param request validated create payload
+     * @return created brand
+     */
+    BrandResponse createBrand(BrandRequest request);
+
+    /**
+     * Update an existing brand.
+     *
+     * @param brandId brand ID
+     * @param request validated update payload
+     * @return updated brand
+     */
+    BrandResponse updateBrand(Long brandId, BrandRequest request);
+
+    /**
+     * Soft delete a brand by deactivating it.
+     *
+     * @param brandId brand ID
+     */
+    void deleteBrand(Long brandId);
 }

--- a/backend/src/main/java/com/urbanfresh/service/SupplierService.java
+++ b/backend/src/main/java/com/urbanfresh/service/SupplierService.java
@@ -1,0 +1,28 @@
+package com.urbanfresh.service;
+
+import java.util.List;
+
+import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierProductResponse;
+
+/**
+ * Service Layer – Supplier-facing operations with brand scoping.
+ */
+public interface SupplierService {
+
+    /**
+     * Get all brands assigned to the authenticated supplier.
+     *
+     * @param supplierEmail authenticated supplier email
+     * @return assigned brands
+     */
+    List<BrandResponse> getAssignedBrands(String supplierEmail);
+
+    /**
+     * Get products visible to the authenticated supplier.
+     *
+     * @param supplierEmail authenticated supplier email
+     * @return brand-filtered products
+     */
+    List<SupplierProductResponse> getSupplierProducts(String supplierEmail);
+}

--- a/backend/src/main/java/com/urbanfresh/service/impl/AdminDashboardServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/AdminDashboardServiceImpl.java
@@ -6,8 +6,10 @@ import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Service;
 
 import com.urbanfresh.dto.AdminDashboardResponse;
+import com.urbanfresh.model.Role;
 import com.urbanfresh.repository.OrderRepository;
 import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.repository.UserRepository;
 import com.urbanfresh.service.AdminDashboardService;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
     
     private final OrderRepository orderRepository;
     private final ProductRepository productRepository;
+    private final UserRepository userRepository;
     
     @Override
     public AdminDashboardResponse getDashboardMetrics() {
@@ -31,13 +34,13 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
         // KPI Metrics
         response.setTotalOrders(orderRepository.count());
         response.setTotalRevenue(calculateTotalRevenue());
-        response.setActiveSuppliersCount(0); // TODO: requires Supplier model in future sprint
+        response.setActiveSuppliersCount(userRepository.countByRoleAndIsActiveTrue(Role.SUPPLIER));
         response.setTotalProductsCount((int) productRepository.count());
         
-        // Alerts (placeholder - will be enhanced when inventory expires/low-stock tracking added)
-        response.setLowStockItemsCount(0); // TODO: enhance with actual low-stock logic from SCRUM-25
-        response.setNearExpiryItemsCount(0); // TODO: enhance when expiry dates tracked
-        response.setWastePercentage(0.0); // TODO: calculate when waste metrics added
+        // Alerts remain zero until inventory analytics features are enabled.
+        response.setLowStockItemsCount(0);
+        response.setNearExpiryItemsCount(0);
+        response.setWastePercentage(0.0);
         
         // Summary
         AdminDashboardResponse.DashboardSummary summary = new AdminDashboardResponse.DashboardSummary();

--- a/backend/src/main/java/com/urbanfresh/service/impl/AdminProductServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/AdminProductServiceImpl.java
@@ -7,8 +7,11 @@ import org.springframework.stereotype.Service;
 
 import com.urbanfresh.dto.request.ProductRequest;
 import com.urbanfresh.dto.response.AdminProductResponse;
+import com.urbanfresh.exception.BrandNotFoundException;
 import com.urbanfresh.exception.ProductNotFoundException;
+import com.urbanfresh.model.Brand;
 import com.urbanfresh.model.Product;
+import com.urbanfresh.repository.BrandRepository;
 import com.urbanfresh.repository.ProductRepository;
 import com.urbanfresh.service.AdminProductService;
 
@@ -24,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminProductServiceImpl implements AdminProductService {
 
     private final ProductRepository productRepository;
+    private final BrandRepository brandRepository;
 
     /**
      * Returns all products sorted by name, paginated, for the admin table.
@@ -65,6 +69,7 @@ public class AdminProductServiceImpl implements AdminProductService {
                 .price(request.getPrice())
                 .unit(request.getUnit() != null ? request.getUnit() : com.urbanfresh.model.PricingUnit.PER_ITEM)
                 .category(request.getCategory())
+            .brand(resolveBrand(request.getBrandId()))
                 .imageUrl(request.getImageUrl())
                 .featured(request.isFeatured())
                 .expiryDate(request.getExpiryDate())
@@ -91,6 +96,7 @@ public class AdminProductServiceImpl implements AdminProductService {
         product.setPrice(request.getPrice());
         product.setUnit(request.getUnit() != null ? request.getUnit() : com.urbanfresh.model.PricingUnit.PER_ITEM);
         product.setCategory(request.getCategory());
+        product.setBrand(resolveBrand(request.getBrandId()));
         product.setImageUrl(request.getImageUrl());
         product.setFeatured(request.isFeatured());
         product.setExpiryDate(request.getExpiryDate());
@@ -119,8 +125,23 @@ public class AdminProductServiceImpl implements AdminProductService {
                 .orElseThrow(() -> new ProductNotFoundException(id));
     }
 
+    /**
+     * Resolve optional brand ID to entity.
+     *
+     * @param brandId optional brand ID
+     * @return resolved Brand entity or null for unbranded products
+     */
+    private Brand resolveBrand(Long brandId) {
+        if (brandId == null) {
+            return null;
+        }
+        return brandRepository.findById(brandId)
+                .orElseThrow(() -> new BrandNotFoundException(brandId));
+    }
+
     /** Maps a Product entity to the admin response DTO (includes stockQuantity). */
     private AdminProductResponse toAdminResponse(Product product) {
+        Brand brand = product.getBrand();
         return AdminProductResponse.builder()
                 .id(product.getId())
                 .name(product.getName())
@@ -128,6 +149,9 @@ public class AdminProductServiceImpl implements AdminProductService {
                 .price(product.getPrice())
                 .unit(product.getUnit())
                 .category(product.getCategory())
+                .brandId(brand != null ? brand.getId() : null)
+                .brandName(brand != null ? brand.getName() : null)
+                .brandCode(brand != null ? brand.getCode() : null)
                 .imageUrl(product.getImageUrl())
                 .featured(product.isFeatured())
                 .expiryDate(product.getExpiryDate())

--- a/backend/src/main/java/com/urbanfresh/service/impl/AdminServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/AdminServiceImpl.java
@@ -1,5 +1,9 @@
 package com.urbanfresh.service.impl;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -7,14 +11,24 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.urbanfresh.dto.request.CreateDeliveryPersonnelRequest;
+import com.urbanfresh.dto.request.CreateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateDeliveryPersonnelStatusRequest;
+import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
 import com.urbanfresh.dto.response.AdminStatsResponse;
+import com.urbanfresh.dto.response.BrandResponse;
 import com.urbanfresh.dto.response.DeliveryPersonnelResponse;
+import com.urbanfresh.dto.response.SupplierResponse;
+import com.urbanfresh.exception.BrandAssignmentException;
 import com.urbanfresh.exception.DuplicateEmailException;
 import com.urbanfresh.exception.UserNotFoundException;
+import com.urbanfresh.model.Brand;
 import com.urbanfresh.model.Role;
+import com.urbanfresh.model.SupplierBrand;
+import com.urbanfresh.model.SupplierBrandId;
 import com.urbanfresh.model.User;
+import com.urbanfresh.repository.BrandRepository;
 import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.repository.SupplierBrandRepository;
 import com.urbanfresh.repository.UserRepository;
 import com.urbanfresh.service.AdminService;
 
@@ -31,6 +45,8 @@ public class AdminServiceImpl implements AdminService {
 
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
+    private final BrandRepository brandRepository;
+    private final SupplierBrandRepository supplierBrandRepository;
     private final PasswordEncoder passwordEncoder;
 
     /**
@@ -107,6 +123,98 @@ public class AdminServiceImpl implements AdminService {
         return toDeliveryPersonnelResponse(updated);
     }
 
+    /**
+     * Create a new supplier account and assign brands in a single transaction.
+     *
+     * @param request validated supplier creation payload
+     * @return created supplier response with assigned brands
+     */
+    @Override
+    @Transactional
+    public SupplierResponse createSupplier(CreateSupplierRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateEmailException(request.getEmail());
+        }
+
+        if (request.getBrandIds() == null || request.getBrandIds().isEmpty()) {
+            throw new BrandAssignmentException("At least one brand must be assigned to a supplier.");
+        }
+
+        Set<Long> uniqueBrandIds = new HashSet<>(request.getBrandIds());
+        List<Brand> brands = brandRepository.findAllById(uniqueBrandIds);
+        if (brands.size() != uniqueBrandIds.size()) {
+            throw new BrandAssignmentException("One or more provided brand IDs are invalid.");
+        }
+
+        User supplier = User.builder()
+                .name(request.getName())
+                .email(request.getEmail().toLowerCase().trim())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .phone(request.getPhone())
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+
+        User savedSupplier = userRepository.save(supplier);
+
+        List<SupplierBrand> mappings = brands.stream()
+                .map(brand -> SupplierBrand.builder()
+                        .id(new SupplierBrandId(savedSupplier.getId(), brand.getId()))
+                        .supplier(savedSupplier)
+                        .brand(brand)
+                        .build())
+                .toList();
+
+        supplierBrandRepository.saveAll(mappings);
+        return toSupplierResponse(savedSupplier, mappings);
+    }
+
+    /**
+     * Retrieve all suppliers and their assigned brands.
+     *
+     * @return list of supplier responses
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<SupplierResponse> getSuppliers() {
+        return userRepository.findByRoleOrderByNameAsc(Role.SUPPLIER)
+                .stream()
+                .map(this::toSupplierResponse)
+                .toList();
+    }
+
+    /**
+     * Activate or deactivate an existing supplier account.
+     *
+     * @param supplierId supplier account ID
+     * @param request activation payload
+     * @return updated supplier response
+     */
+    @Override
+    @Transactional
+    public SupplierResponse updateSupplierStatus(Long supplierId, UpdateSupplierStatusRequest request) {
+        User supplier = userRepository.findByIdAndRole(supplierId, Role.SUPPLIER)
+                .orElseThrow(() -> new UserNotFoundException("Supplier not found with ID: " + supplierId));
+
+        supplier.setIsActive(request.getIsActive());
+        User updated = userRepository.save(supplier);
+        return toSupplierResponse(updated);
+    }
+
+    /**
+     * Retrieve active brands for assignment forms.
+     *
+     * @return list of active brands
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<BrandResponse> getActiveBrands() {
+        return brandRepository.findByActiveTrueOrderByNameAsc()
+                .stream()
+                .map(this::toBrandResponse)
+                .toList();
+    }
+
     /** Map User entity → DeliveryPersonnelResponse DTO. Centralised to keep mapping DRY. */
     private DeliveryPersonnelResponse toDeliveryPersonnelResponse(User user) {
         return DeliveryPersonnelResponse.builder()
@@ -116,6 +224,35 @@ public class AdminServiceImpl implements AdminService {
                 .phone(user.getPhone())
                 .isActive(user.getIsActive())
                 .createdAt(user.getCreatedAt())
+                .build();
+    }
+
+    private SupplierResponse toSupplierResponse(User supplier) {
+        List<SupplierBrand> mappings = supplierBrandRepository.findBySupplierId(supplier.getId());
+        return toSupplierResponse(supplier, mappings);
+    }
+
+    private SupplierResponse toSupplierResponse(User supplier, List<SupplierBrand> mappings) {
+        List<BrandResponse> brands = mappings.stream()
+                .map(mapping -> toBrandResponse(mapping.getBrand()))
+                .toList();
+
+        return SupplierResponse.builder()
+                .id(supplier.getId())
+                .name(supplier.getName())
+                .email(supplier.getEmail())
+                .phone(supplier.getPhone())
+                .isActive(supplier.getIsActive())
+                .createdAt(supplier.getCreatedAt())
+                .brands(brands)
+                .build();
+    }
+
+    private BrandResponse toBrandResponse(Brand brand) {
+        return BrandResponse.builder()
+                .id(brand.getId())
+                .name(brand.getName())
+                .code(brand.getCode())
                 .build();
     }
 }

--- a/backend/src/main/java/com/urbanfresh/service/impl/AdminServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/AdminServiceImpl.java
@@ -12,13 +12,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.urbanfresh.dto.request.CreateDeliveryPersonnelRequest;
 import com.urbanfresh.dto.request.CreateSupplierRequest;
+import com.urbanfresh.dto.request.BrandRequest;
 import com.urbanfresh.dto.request.UpdateDeliveryPersonnelStatusRequest;
+import com.urbanfresh.dto.request.UpdateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
 import com.urbanfresh.dto.response.AdminStatsResponse;
 import com.urbanfresh.dto.response.BrandResponse;
 import com.urbanfresh.dto.response.DeliveryPersonnelResponse;
 import com.urbanfresh.dto.response.SupplierResponse;
 import com.urbanfresh.exception.BrandAssignmentException;
+import com.urbanfresh.exception.BrandConflictException;
+import com.urbanfresh.exception.BrandNotFoundException;
 import com.urbanfresh.exception.DuplicateEmailException;
 import com.urbanfresh.exception.UserNotFoundException;
 import com.urbanfresh.model.Brand;
@@ -141,10 +145,7 @@ public class AdminServiceImpl implements AdminService {
         }
 
         Set<Long> uniqueBrandIds = new HashSet<>(request.getBrandIds());
-        List<Brand> brands = brandRepository.findAllById(uniqueBrandIds);
-        if (brands.size() != uniqueBrandIds.size()) {
-            throw new BrandAssignmentException("One or more provided brand IDs are invalid.");
-        }
+        List<Brand> brands = loadValidActiveBrands(uniqueBrandIds);
 
         User supplier = User.builder()
                 .name(request.getName())
@@ -202,6 +203,39 @@ public class AdminServiceImpl implements AdminService {
     }
 
     /**
+     * Update supplier profile details and replace assigned brands.
+     *
+     * @param supplierId supplier account ID
+     * @param request validated update payload
+     * @return updated supplier response with assigned brands
+     */
+    @Override
+    @Transactional
+    public SupplierResponse updateSupplier(Long supplierId, UpdateSupplierRequest request) {
+        User supplier = userRepository.findByIdAndRole(supplierId, Role.SUPPLIER)
+                .orElseThrow(() -> new UserNotFoundException("Supplier not found with ID: " + supplierId));
+
+        Set<Long> uniqueBrandIds = new HashSet<>(request.getBrandIds());
+        List<Brand> brands = loadValidActiveBrands(uniqueBrandIds);
+
+        supplier.setName(request.getName().trim());
+        supplier.setPhone(normalizePhone(request.getPhone()));
+        userRepository.save(supplier);
+
+        supplierBrandRepository.deleteBySupplierId(supplierId);
+        List<SupplierBrand> mappings = brands.stream()
+                .map(brand -> SupplierBrand.builder()
+                        .id(new SupplierBrandId(supplierId, brand.getId()))
+                        .supplier(supplier)
+                        .brand(brand)
+                        .build())
+                .toList();
+        supplierBrandRepository.saveAll(mappings);
+
+        return toSupplierResponse(supplier, mappings);
+    }
+
+    /**
      * Retrieve active brands for assignment forms.
      *
      * @return list of active brands
@@ -213,6 +247,90 @@ public class AdminServiceImpl implements AdminService {
                 .stream()
                 .map(this::toBrandResponse)
                 .toList();
+    }
+
+    /**
+     * Retrieve all brands for admin management views.
+     *
+     * @return list of all brands
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<BrandResponse> getAllBrands() {
+        return brandRepository.findAllByOrderByNameAsc()
+                .stream()
+                .map(this::toBrandResponse)
+                .toList();
+    }
+
+    /**
+     * Create a new brand with uniqueness validation for name and code.
+     *
+     * @param request validated create payload
+     * @return created brand response
+     */
+    @Override
+    @Transactional
+    public BrandResponse createBrand(BrandRequest request) {
+        String normalizedName = normalizeRequired(request.getName());
+        String normalizedCode = normalizeRequired(request.getCode()).toUpperCase();
+
+        if (brandRepository.existsByNameIgnoreCase(normalizedName)) {
+            throw new BrandConflictException("A brand with this name already exists.");
+        }
+        if (brandRepository.existsByCodeIgnoreCase(normalizedCode)) {
+            throw new BrandConflictException("A brand with this code already exists.");
+        }
+
+        Brand brand = Brand.builder()
+                .name(normalizedName)
+                .code(normalizedCode)
+                .active(true)
+                .build();
+
+        return toBrandResponse(brandRepository.save(brand));
+    }
+
+    /**
+     * Update a brand's display name and code with uniqueness checks.
+     *
+     * @param brandId brand ID
+     * @param request validated update payload
+     * @return updated brand response
+     */
+    @Override
+    @Transactional
+    public BrandResponse updateBrand(Long brandId, BrandRequest request) {
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(() -> new BrandNotFoundException(brandId));
+
+        String normalizedName = normalizeRequired(request.getName());
+        String normalizedCode = normalizeRequired(request.getCode()).toUpperCase();
+
+        if (brandRepository.existsByNameIgnoreCaseAndIdNot(normalizedName, brandId)) {
+            throw new BrandConflictException("A brand with this name already exists.");
+        }
+        if (brandRepository.existsByCodeIgnoreCaseAndIdNot(normalizedCode, brandId)) {
+            throw new BrandConflictException("A brand with this code already exists.");
+        }
+
+        brand.setName(normalizedName);
+        brand.setCode(normalizedCode);
+        return toBrandResponse(brandRepository.save(brand));
+    }
+
+    /**
+     * Soft delete a brand by setting active=false.
+     *
+     * @param brandId brand ID
+     */
+    @Override
+    @Transactional
+    public void deleteBrand(Long brandId) {
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(() -> new BrandNotFoundException(brandId));
+        brand.setActive(false);
+        brandRepository.save(brand);
     }
 
     /** Map User entity → DeliveryPersonnelResponse DTO. Centralised to keep mapping DRY. */
@@ -253,6 +371,31 @@ public class AdminServiceImpl implements AdminService {
                 .id(brand.getId())
                 .name(brand.getName())
                 .code(brand.getCode())
+                .active(brand.getActive())
                 .build();
+    }
+
+    private List<Brand> loadValidActiveBrands(Set<Long> brandIds) {
+        List<Brand> brands = brandRepository.findAllById(brandIds);
+        if (brands.size() != brandIds.size()) {
+            throw new BrandAssignmentException("One or more provided brand IDs are invalid.");
+        }
+        boolean hasInactiveBrand = brands.stream().anyMatch(brand -> !Boolean.TRUE.equals(brand.getActive()));
+        if (hasInactiveBrand) {
+            throw new BrandAssignmentException("Only active brands can be assigned to suppliers.");
+        }
+        return brands;
+    }
+
+    private String normalizeRequired(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private String normalizePhone(String phone) {
+        if (phone == null) {
+            return null;
+        }
+        String trimmed = phone.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/backend/src/main/java/com/urbanfresh/service/impl/AuthServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.urbanfresh.dto.response.LoginResponse;
 import com.urbanfresh.dto.response.RegisterResponse;
 import com.urbanfresh.exception.DuplicateEmailException;
 import com.urbanfresh.exception.InvalidCredentialsException;
+import com.urbanfresh.exception.SupplierInactiveException;
 import com.urbanfresh.model.Role;
 import com.urbanfresh.model.User;
 import com.urbanfresh.repository.UserRepository;
@@ -78,8 +79,12 @@ public class AuthServiceImpl implements AuthService {
             throw new InvalidCredentialsException();
         }
 
-        // Check if user account is active (admin may have deactivated it)
-        // Treat inactive as invalid credentials for security (don't reveal account status)
+        // Provide explicit guidance for deactivated suppliers as required by business rules.
+        if (user.getRole() == Role.SUPPLIER && (user.getIsActive() == null || !user.getIsActive())) {
+            throw new SupplierInactiveException();
+        }
+
+        // Keep non-supplier behavior generic to avoid leaking account state.
         if (user.getIsActive() == null || !user.getIsActive()) {
             throw new InvalidCredentialsException();
         }

--- a/backend/src/main/java/com/urbanfresh/service/impl/SupplierServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/SupplierServiceImpl.java
@@ -1,0 +1,83 @@
+package com.urbanfresh.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierProductResponse;
+import com.urbanfresh.exception.SupplierInactiveException;
+import com.urbanfresh.model.Product;
+import com.urbanfresh.model.Role;
+import com.urbanfresh.model.SupplierBrand;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.repository.SupplierBrandRepository;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.SupplierService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Service Layer – Implements supplier-facing brand-scoped operations.
+ */
+@Service
+@RequiredArgsConstructor
+public class SupplierServiceImpl implements SupplierService {
+
+    private final UserRepository userRepository;
+    private final SupplierBrandRepository supplierBrandRepository;
+    private final ProductRepository productRepository;
+
+    /**
+     * Get all brands assigned to the authenticated supplier.
+     *
+     * @param supplierEmail authenticated supplier email
+     * @return assigned brands
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<BrandResponse> getAssignedBrands(String supplierEmail) {
+        User supplier = getActiveSupplierByEmail(supplierEmail);
+        List<SupplierBrand> mappings = supplierBrandRepository.findBySupplierId(supplier.getId());
+
+        return mappings.stream()
+                .map(mapping -> BrandResponse.builder()
+                        .id(mapping.getBrand().getId())
+                        .name(mapping.getBrand().getName())
+                        .code(mapping.getBrand().getCode())
+                        .build())
+                .toList();
+    }
+
+    /**
+     * Get products visible to the authenticated supplier.
+     *
+     * @param supplierEmail authenticated supplier email
+     * @return brand-filtered products
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<SupplierProductResponse> getSupplierProducts(String supplierEmail) {
+        User supplier = getActiveSupplierByEmail(supplierEmail);
+        List<Product> products = productRepository.findProductsForSupplier(supplier.getId());
+
+        return products.stream()
+                .map(product -> SupplierProductResponse.builder()
+                        .id(product.getId())
+                        .name(product.getName())
+                        .category(product.getCategory())
+                        .brandName(product.getBrand() != null ? product.getBrand().getName() : null)
+                        .price(product.getPrice())
+                        .unit(product.getUnit())
+                        .stockQuantity(product.getStockQuantity())
+                        .build())
+                .toList();
+    }
+
+    private User getActiveSupplierByEmail(String supplierEmail) {
+        return userRepository.findByEmailAndRoleAndIsActiveTrue(supplierEmail.toLowerCase().trim(), Role.SUPPLIER)
+                .orElseThrow(SupplierInactiveException::new);
+    }
+}

--- a/backend/src/test/java/com/urbanfresh/service/AdminServiceImplTest.java
+++ b/backend/src/test/java/com/urbanfresh/service/AdminServiceImplTest.java
@@ -1,0 +1,193 @@
+package com.urbanfresh.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.urbanfresh.dto.request.CreateSupplierRequest;
+import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
+import com.urbanfresh.dto.response.SupplierResponse;
+import com.urbanfresh.exception.BrandAssignmentException;
+import com.urbanfresh.exception.DuplicateEmailException;
+import com.urbanfresh.exception.UserNotFoundException;
+import com.urbanfresh.model.Brand;
+import com.urbanfresh.model.Role;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.BrandRepository;
+import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.repository.SupplierBrandRepository;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.impl.AdminServiceImpl;
+
+/**
+ * Test Layer – Unit tests for supplier account onboarding and status management.
+ */
+@ExtendWith(MockitoExtension.class)
+class AdminServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+        @SuppressWarnings("unused")
+    private ProductRepository productRepository;
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @Mock
+    private SupplierBrandRepository supplierBrandRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AdminServiceImpl adminService;
+
+    /**
+     * Verifies supplier account is created and persisted with assigned brands.
+     */
+    @Test
+    void createSupplier_createsSupplierWithBrandMappings() {
+        CreateSupplierRequest request = new CreateSupplierRequest(
+                "Saira Supplier",
+                "supplier@urbanfresh.test",
+                "Temp@12345",
+                "0775551212",
+                List.of(1L, 2L)
+        );
+
+        Brand brandOne = Brand.builder().id(1L).name("FreshHarvest").code("FRESH").active(true).build();
+        Brand brandTwo = Brand.builder().id(2L).name("GreenLeaf").code("GREEN").active(true).build();
+
+        User savedSupplier = User.builder()
+                .id(30L)
+                .name("Saira Supplier")
+                .email("supplier@urbanfresh.test")
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+
+        when(userRepository.existsByEmail("supplier@urbanfresh.test")).thenReturn(false);
+        when(brandRepository.findAllById(any())).thenReturn(List.of(brandOne, brandTwo));
+        when(passwordEncoder.encode("Temp@12345")).thenReturn("encoded-password");
+        when(userRepository.save(any(User.class))).thenReturn(savedSupplier);
+
+        SupplierResponse response = adminService.createSupplier(request);
+
+        assertThat(response.getId()).isEqualTo(30L);
+        assertThat(response.getEmail()).isEqualTo("supplier@urbanfresh.test");
+        assertThat(response.getBrands()).hasSize(2);
+        verify(supplierBrandRepository).saveAll(any());
+    }
+
+    /**
+     * Verifies supplier creation fails when brand assignment is missing.
+     */
+    @Test
+    void createSupplier_throwsWhenBrandAssignmentMissing() {
+        CreateSupplierRequest request = new CreateSupplierRequest(
+                "Saira Supplier",
+                "supplier@urbanfresh.test",
+                "Temp@12345",
+                "0775551212",
+                List.of()
+        );
+
+        when(userRepository.existsByEmail("supplier@urbanfresh.test")).thenReturn(false);
+
+        assertThatThrownBy(() -> adminService.createSupplier(request))
+                .isInstanceOf(BrandAssignmentException.class)
+                .hasMessageContaining("At least one brand must be assigned");
+
+        verify(brandRepository, never()).findAllById(any());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    /**
+     * Verifies supplier creation fails when any brand ID is invalid.
+     */
+    @Test
+    void createSupplier_throwsWhenBrandIdsInvalid() {
+        CreateSupplierRequest request = new CreateSupplierRequest(
+                "Saira Supplier",
+                "supplier@urbanfresh.test",
+                "Temp@12345",
+                "0775551212",
+                List.of(1L, 999L)
+        );
+
+        Brand brandOne = Brand.builder().id(1L).name("FreshHarvest").code("FRESH").active(true).build();
+
+        when(userRepository.existsByEmail("supplier@urbanfresh.test")).thenReturn(false);
+        when(brandRepository.findAllById(any())).thenReturn(List.of(brandOne));
+
+        assertThatThrownBy(() -> adminService.createSupplier(request))
+                .isInstanceOf(BrandAssignmentException.class)
+                .hasMessageContaining("invalid");
+    }
+
+    /**
+     * Verifies duplicate supplier email is rejected.
+     */
+    @Test
+    void createSupplier_throwsWhenEmailExists() {
+        CreateSupplierRequest request = new CreateSupplierRequest(
+                "Saira Supplier",
+                "supplier@urbanfresh.test",
+                "Temp@12345",
+                "0775551212",
+                List.of(1L)
+        );
+
+        when(userRepository.existsByEmail("supplier@urbanfresh.test")).thenReturn(true);
+
+        assertThatThrownBy(() -> adminService.createSupplier(request))
+                .isInstanceOf(DuplicateEmailException.class);
+    }
+
+    /**
+     * Verifies supplier account status can be toggled by admin.
+     */
+    @Test
+    void updateSupplierStatus_updatesSupplierActivationFlag() {
+        User supplier = User.builder()
+                .id(44L)
+                .name("Supplier")
+                .email("supplier@urbanfresh.test")
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+
+        when(userRepository.findByIdAndRole(44L, Role.SUPPLIER)).thenReturn(Optional.of(supplier));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(supplierBrandRepository.findBySupplierId(44L)).thenReturn(List.of());
+
+        SupplierResponse response = adminService.updateSupplierStatus(44L, new UpdateSupplierStatusRequest(false));
+
+        assertThat(response.getIsActive()).isFalse();
+    }
+
+    /**
+     * Verifies status update rejects unknown supplier IDs.
+     */
+    @Test
+    void updateSupplierStatus_throwsWhenSupplierNotFound() {
+        when(userRepository.findByIdAndRole(44L, Role.SUPPLIER)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminService.updateSupplierStatus(44L, new UpdateSupplierStatusRequest(false)))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/urbanfresh/service/AdminServiceImplTest.java
+++ b/backend/src/test/java/com/urbanfresh/service/AdminServiceImplTest.java
@@ -16,10 +16,14 @@ import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.urbanfresh.dto.request.BrandRequest;
 import com.urbanfresh.dto.request.CreateSupplierRequest;
+import com.urbanfresh.dto.request.UpdateSupplierRequest;
 import com.urbanfresh.dto.request.UpdateSupplierStatusRequest;
+import com.urbanfresh.dto.response.BrandResponse;
 import com.urbanfresh.dto.response.SupplierResponse;
 import com.urbanfresh.exception.BrandAssignmentException;
+import com.urbanfresh.exception.BrandConflictException;
 import com.urbanfresh.exception.DuplicateEmailException;
 import com.urbanfresh.exception.UserNotFoundException;
 import com.urbanfresh.model.Brand;
@@ -189,5 +193,63 @@ class AdminServiceImplTest {
 
         assertThatThrownBy(() -> adminService.updateSupplierStatus(44L, new UpdateSupplierStatusRequest(false)))
                 .isInstanceOf(UserNotFoundException.class);
+    }
+
+    /**
+     * Verifies supplier update replaces brand assignments.
+     */
+    @Test
+    void updateSupplier_replacesBrandMappings() {
+        User supplier = User.builder()
+                .id(44L)
+                .name("Old Supplier")
+                .email("supplier@urbanfresh.test")
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+        Brand brandOne = Brand.builder().id(1L).name("FreshHarvest").code("FRESH").active(true).build();
+        Brand brandTwo = Brand.builder().id(2L).name("GreenLeaf").code("GREEN").active(true).build();
+
+        when(userRepository.findByIdAndRole(44L, Role.SUPPLIER)).thenReturn(Optional.of(supplier));
+        when(brandRepository.findAllById(any())).thenReturn(List.of(brandOne, brandTwo));
+
+        SupplierResponse response = adminService.updateSupplier(
+                44L,
+                new UpdateSupplierRequest("Updated Supplier", "0775551212", List.of(1L, 2L))
+        );
+
+        assertThat(response.getName()).isEqualTo("Updated Supplier");
+        assertThat(response.getBrands()).hasSize(2);
+        verify(supplierBrandRepository).deleteBySupplierId(44L);
+        verify(supplierBrandRepository).saveAll(any());
+    }
+
+    /**
+     * Verifies brand create succeeds with unique name and code.
+     */
+    @Test
+    void createBrand_createsNewBrand() {
+        Brand savedBrand = Brand.builder().id(10L).name("Island Green").code("IG").active(true).build();
+
+        when(brandRepository.existsByNameIgnoreCase("Island Green")).thenReturn(false);
+        when(brandRepository.existsByCodeIgnoreCase("IG")).thenReturn(false);
+        when(brandRepository.save(any(Brand.class))).thenReturn(savedBrand);
+
+        BrandResponse response = adminService.createBrand(new BrandRequest("Island Green", "ig"));
+
+        assertThat(response.getName()).isEqualTo("Island Green");
+        assertThat(response.getCode()).isEqualTo("IG");
+        assertThat(response.getActive()).isTrue();
+    }
+
+    /**
+     * Verifies create brand rejects duplicate name.
+     */
+    @Test
+    void createBrand_throwsWhenNameExists() {
+        when(brandRepository.existsByNameIgnoreCase("Island Green")).thenReturn(true);
+
+        assertThatThrownBy(() -> adminService.createBrand(new BrandRequest("Island Green", "IG")))
+                .isInstanceOf(BrandConflictException.class);
     }
 }

--- a/backend/src/test/java/com/urbanfresh/service/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/urbanfresh/service/AuthServiceImplTest.java
@@ -1,0 +1,107 @@
+package com.urbanfresh.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.urbanfresh.dto.request.LoginRequest;
+import com.urbanfresh.dto.response.LoginResponse;
+import com.urbanfresh.exception.InvalidCredentialsException;
+import com.urbanfresh.exception.SupplierInactiveException;
+import com.urbanfresh.model.Role;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.security.JwtUtil;
+import com.urbanfresh.service.impl.AuthServiceImpl;
+
+/**
+ * Test Layer – Unit tests for login behavior with supplier deactivation rules.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    /**
+     * Verifies an inactive supplier cannot authenticate.
+     */
+    @Test
+    void login_throwsWhenSupplierInactive() {
+        LoginRequest request = new LoginRequest("supplier@urbanfresh.test", "Temp@12345");
+        User supplier = User.builder()
+                .email("supplier@urbanfresh.test")
+                .password("encoded")
+                .role(Role.SUPPLIER)
+                .isActive(false)
+                .build();
+
+        when(userRepository.findByEmail("supplier@urbanfresh.test")).thenReturn(Optional.of(supplier));
+        when(passwordEncoder.matches("Temp@12345", "encoded")).thenReturn(true);
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(SupplierInactiveException.class);
+    }
+
+    /**
+     * Verifies inactive non-supplier users keep generic invalid-credentials behavior.
+     */
+    @Test
+    void login_throwsGenericInvalidCredentialsWhenNonSupplierInactive() {
+        LoginRequest request = new LoginRequest("delivery@urbanfresh.test", "Temp@12345");
+        User delivery = User.builder()
+                .email("delivery@urbanfresh.test")
+                .password("encoded")
+                .role(Role.DELIVERY)
+                .isActive(false)
+                .build();
+
+        when(userRepository.findByEmail("delivery@urbanfresh.test")).thenReturn(Optional.of(delivery));
+        when(passwordEncoder.matches("Temp@12345", "encoded")).thenReturn(true);
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(InvalidCredentialsException.class);
+    }
+
+    /**
+     * Verifies active suppliers can authenticate successfully.
+     */
+    @Test
+    void login_returnsTokenWhenSupplierActive() {
+        LoginRequest request = new LoginRequest("supplier@urbanfresh.test", "Temp@12345");
+        User supplier = User.builder()
+                .email("supplier@urbanfresh.test")
+                .name("Saira Supplier")
+                .password("encoded")
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+
+        when(userRepository.findByEmail("supplier@urbanfresh.test")).thenReturn(Optional.of(supplier));
+        when(passwordEncoder.matches("Temp@12345", "encoded")).thenReturn(true);
+        when(jwtUtil.generateToken("supplier@urbanfresh.test", "SUPPLIER")).thenReturn("jwt-token");
+
+        LoginResponse response = authService.login(request);
+
+        assertThat(response.getToken()).isEqualTo("jwt-token");
+        assertThat(response.getRole()).isEqualTo("SUPPLIER");
+    }
+}

--- a/backend/src/test/java/com/urbanfresh/service/SupplierServiceImplTest.java
+++ b/backend/src/test/java/com/urbanfresh/service/SupplierServiceImplTest.java
@@ -1,0 +1,127 @@
+package com.urbanfresh.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierProductResponse;
+import com.urbanfresh.exception.SupplierInactiveException;
+import com.urbanfresh.model.Brand;
+import com.urbanfresh.model.PricingUnit;
+import com.urbanfresh.model.Product;
+import com.urbanfresh.model.Role;
+import com.urbanfresh.model.SupplierBrand;
+import com.urbanfresh.model.SupplierBrandId;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.repository.SupplierBrandRepository;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.impl.SupplierServiceImpl;
+
+/**
+ * Test Layer – Unit tests for supplier brand-scoped service behavior.
+ */
+@ExtendWith(MockitoExtension.class)
+class SupplierServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SupplierBrandRepository supplierBrandRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private SupplierServiceImpl supplierService;
+
+    /**
+     * Verifies supplier products are fetched using supplier ID and mapped into DTOs.
+     */
+    @Test
+    void getSupplierProducts_returnsBrandScopedProducts() {
+        User supplier = User.builder()
+                .id(10L)
+                .email("supplier@urbanfresh.test")
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+
+        Brand brand = Brand.builder().id(1L).name("FreshHarvest").code("FRESH").active(true).build();
+        Product product = Product.builder()
+                .id(100L)
+                .name("Organic Bananas")
+                .category("Fruits")
+                .brand(brand)
+                .price(BigDecimal.valueOf(200))
+                .unit(PricingUnit.PER_KG)
+                .stockQuantity(50)
+                .build();
+
+        when(userRepository.findByEmailAndRoleAndIsActiveTrue("supplier@urbanfresh.test", Role.SUPPLIER))
+                .thenReturn(Optional.of(supplier));
+        when(productRepository.findProductsForSupplier(10L)).thenReturn(List.of(product));
+
+        List<SupplierProductResponse> result = supplierService.getSupplierProducts("supplier@urbanfresh.test");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Organic Bananas");
+        assertThat(result.get(0).getBrandName()).isEqualTo("FreshHarvest");
+        verify(productRepository).findProductsForSupplier(10L);
+    }
+
+    /**
+     * Verifies assigned supplier brands are returned for dashboard rendering.
+     */
+    @Test
+    void getAssignedBrands_returnsMappedBrands() {
+        User supplier = User.builder()
+                .id(10L)
+                .email("supplier@urbanfresh.test")
+                .role(Role.SUPPLIER)
+                .isActive(true)
+                .build();
+
+        Brand brand = Brand.builder().id(1L).name("FreshHarvest").code("FRESH").active(true).build();
+        SupplierBrand mapping = SupplierBrand.builder()
+                .id(new SupplierBrandId(10L, 1L))
+                .supplier(supplier)
+                .brand(brand)
+                .build();
+
+        when(userRepository.findByEmailAndRoleAndIsActiveTrue("supplier@urbanfresh.test", Role.SUPPLIER))
+                .thenReturn(Optional.of(supplier));
+        when(supplierBrandRepository.findBySupplierId(10L)).thenReturn(List.of(mapping));
+
+        List<BrandResponse> result = supplierService.getAssignedBrands("supplier@urbanfresh.test");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("FreshHarvest");
+        assertThat(result.get(0).getCode()).isEqualTo("FRESH");
+    }
+
+    /**
+     * Verifies inactive suppliers are blocked from supplier-scoped APIs.
+     */
+    @Test
+    void getSupplierProducts_throwsWhenSupplierInactive() {
+        when(userRepository.findByEmailAndRoleAndIsActiveTrue("supplier@urbanfresh.test", Role.SUPPLIER))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> supplierService.getSupplierProducts("supplier@urbanfresh.test"))
+                .isInstanceOf(SupplierInactiveException.class);
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import AdminInventoryPage from './pages/admin/AdminInventoryPage';
 import AdminOrdersPage from './pages/admin/AdminOrdersPage';
 import AdminProfilePage from './pages/admin/AdminProfilePage';
 import DeliveryPersonnelPage from './pages/admin/DeliveryPersonnelPage';
+import AdminSuppliersPage from './pages/admin/AdminSuppliersPage';
 import SupplierDashboard from './pages/supplier/SupplierDashboard';
 import DeliveryDashboard from './pages/delivery/DeliveryDashboard';
 import UnauthorizedPage from './pages/error/UnauthorizedPage';
@@ -140,6 +141,14 @@ function App() {
             element={
               <ProtectedRoute allowedRoles={['ADMIN']}>
                 <DeliveryPersonnelPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/suppliers"
+            element={
+              <ProtectedRoute allowedRoles={['ADMIN']}>
+                <AdminSuppliersPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import AdminOrdersPage from './pages/admin/AdminOrdersPage';
 import AdminProfilePage from './pages/admin/AdminProfilePage';
 import DeliveryPersonnelPage from './pages/admin/DeliveryPersonnelPage';
 import AdminSuppliersPage from './pages/admin/AdminSuppliersPage';
+import AdminBrandsPage from './pages/admin/AdminBrandsPage';
 import SupplierDashboard from './pages/supplier/SupplierDashboard';
 import DeliveryDashboard from './pages/delivery/DeliveryDashboard';
 import UnauthorizedPage from './pages/error/UnauthorizedPage';
@@ -149,6 +150,14 @@ function App() {
             element={
               <ProtectedRoute allowedRoles={['ADMIN']}>
                 <AdminSuppliersPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/brands"
+            element={
+              <ProtectedRoute allowedRoles={['ADMIN']}>
+                <AdminBrandsPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/admin/CreateSupplierModal.jsx
+++ b/frontend/src/components/admin/CreateSupplierModal.jsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+
+/**
+ * Presentation Layer – Modal for creating supplier accounts with brand assignments.
+ */
+export default function CreateSupplierModal({ brands, onClose, onSubmit, isSubmitting }) {
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+    phone: '',
+    brandIds: [],
+  });
+  const [errors, setErrors] = useState({});
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  const handleBrandToggle = (brandId) => {
+    setForm((prev) => {
+      const exists = prev.brandIds.includes(brandId);
+      const nextIds = exists
+        ? prev.brandIds.filter((id) => id !== brandId)
+        : [...prev.brandIds, brandId];
+      return { ...prev, brandIds: nextIds };
+    });
+
+    if (errors.brandIds) {
+      setErrors((prev) => ({ ...prev, brandIds: '' }));
+    }
+  };
+
+  const validate = () => {
+    const nextErrors = {};
+
+    if (!form.name.trim()) nextErrors.name = 'Name is required';
+    if (!form.email.trim()) nextErrors.email = 'Email is required';
+    if (!form.password) nextErrors.password = 'Password is required';
+    if (form.password !== form.confirmPassword) nextErrors.confirmPassword = 'Passwords do not match';
+    if (form.brandIds.length === 0) nextErrors.brandIds = 'Select at least one brand';
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    onSubmit({
+      name: form.name.trim(),
+      email: form.email.trim(),
+      password: form.password,
+      phone: form.phone.trim() || null,
+      brandIds: form.brandIds,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 p-4 flex items-center justify-center">
+      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
+        <div className="px-6 py-4 border-b">
+          <h2 className="text-xl font-bold text-gray-900">Create Supplier Account</h2>
+          <p className="text-sm text-gray-500 mt-1">Assign one or more brands during onboarding</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+            <input
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+            {errors.name && <p className="text-xs text-red-600 mt-1">{errors.name}</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+            {errors.email && <p className="text-xs text-red-600 mt-1">{errors.email}</p>}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+              <input
+                type="password"
+                name="password"
+                value={form.password}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-md px-3 py-2"
+              />
+              {errors.password && <p className="text-xs text-red-600 mt-1">{errors.password}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Confirm Password</label>
+              <input
+                type="password"
+                name="confirmPassword"
+                value={form.confirmPassword}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-md px-3 py-2"
+              />
+              {errors.confirmPassword && <p className="text-xs text-red-600 mt-1">{errors.confirmPassword}</p>}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Phone (optional)</label>
+            <input
+              name="phone"
+              value={form.phone}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-md px-3 py-2"
+            />
+          </div>
+
+          <div>
+            <p className="text-sm font-medium text-gray-700 mb-2">Assign Brands</p>
+            <div className="max-h-40 overflow-y-auto border rounded-md p-2 space-y-2">
+              {brands.map((brand) => (
+                <label key={brand.id} className="flex items-center gap-2 text-sm text-gray-800">
+                  <input
+                    type="checkbox"
+                    checked={form.brandIds.includes(brand.id)}
+                    onChange={() => handleBrandToggle(brand.id)}
+                  />
+                  <span>{brand.name}</span>
+                </label>
+              ))}
+            </div>
+            {(errors.brandIds || brands.length === 0) && (
+              <p className="text-xs text-red-600 mt-1">
+                {errors.brandIds || 'No active brands available for assignment'}
+              </p>
+            )}
+          </div>
+        </form>
+
+        <div className="px-6 py-4 border-t bg-gray-50 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="px-4 py-2 rounded-md bg-gray-200 text-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitting || brands.length === 0}
+            className="px-4 py-2 rounded-md bg-green-600 text-white disabled:opacity-60"
+          >
+            {isSubmitting ? 'Creating...' : 'Create Supplier'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/CreateSupplierModal.jsx
+++ b/frontend/src/components/admin/CreateSupplierModal.jsx
@@ -1,18 +1,48 @@
 import { useState } from 'react';
 
 /**
- * Presentation Layer – Modal for creating supplier accounts with brand assignments.
+ * Presentation Layer – Modal for creating and editing supplier accounts with brand assignments.
  */
-export default function CreateSupplierModal({ brands, onClose, onSubmit, isSubmitting }) {
+export default function CreateSupplierModal({
+  brands,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  initialSupplier = null,
+  apiError = '',
+}) {
+  const isEditMode = Boolean(initialSupplier);
+
   const [form, setForm] = useState({
-    name: '',
-    email: '',
+    name: initialSupplier?.name || '',
+    email: initialSupplier?.email || '',
     password: '',
     confirmPassword: '',
-    phone: '',
-    brandIds: [],
+    phone: initialSupplier?.phone || '',
+    brandIds: initialSupplier?.brands?.map((brand) => brand.id) || [],
   });
   const [errors, setErrors] = useState({});
+
+  const PASSWORD_RULES = [
+    { label: 'At least 8 characters', test: (value) => value.length >= 8 },
+    { label: 'One uppercase letter', test: (value) => /[A-Z]/.test(value) },
+    { label: 'One lowercase letter', test: (value) => /[a-z]/.test(value) },
+    { label: 'One digit', test: (value) => /\d/.test(value) },
+    { label: 'One special character (@$!%*?&#)', test: (value) => /[@$!%*?&#]/.test(value) },
+  ];
+
+  const isEmailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim());
+  const isPasswordStrong = PASSWORD_RULES.every((rule) => rule.test(form.password));
+  const isConfirmPasswordValid = isEditMode || (form.confirmPassword && form.password === form.confirmPassword);
+
+  const isFormValid =
+    form.name.trim().length >= 2 &&
+    form.name.trim().length <= 100 &&
+    (isEditMode || (form.email.trim() && isEmailValid)) &&
+    (isEditMode || isPasswordStrong) &&
+    isConfirmPasswordValid &&
+    (!form.phone.trim() || /^\d{10,15}$/.test(form.phone.trim())) &&
+    form.brandIds.length > 0;
 
   const handleChange = (event) => {
     const { name, value } = event.target;
@@ -36,13 +66,95 @@ export default function CreateSupplierModal({ brands, onClose, onSubmit, isSubmi
     }
   };
 
+  const validateField = (name) => {
+    const nextErrors = { ...errors };
+    const normalizedName = form.name.trim();
+    const normalizedEmail = form.email.trim();
+    const normalizedPhone = form.phone.trim();
+
+    if (name === 'name') {
+      if (!normalizedName) {
+        nextErrors.name = 'Name is required';
+      } else if (normalizedName.length < 2 || normalizedName.length > 100) {
+        nextErrors.name = 'Name must be between 2 and 100 characters';
+      }
+    }
+
+    if (name === 'email' && !isEditMode) {
+      if (!normalizedEmail) {
+        nextErrors.email = 'Email is required';
+      } else if (!isEmailValid) {
+        nextErrors.email = 'Enter a valid email address';
+      }
+    }
+
+    if (name === 'password' && !isEditMode) {
+      if (!form.password) {
+        nextErrors.password = 'Password is required';
+      } else if (!isPasswordStrong) {
+        nextErrors.password = 'Password does not meet all requirements';
+      }
+    }
+
+    if (name === 'confirmPassword' && !isEditMode) {
+      if (!form.confirmPassword) {
+        nextErrors.confirmPassword = 'Confirm password is required';
+      } else if (form.password !== form.confirmPassword) {
+        nextErrors.confirmPassword = 'Passwords do not match';
+      }
+    }
+
+    if (name === 'phone') {
+      if (normalizedPhone && !/^\d{10,15}$/.test(normalizedPhone)) {
+        nextErrors.phone = 'Phone must be 10-15 digits';
+      }
+    }
+
+    if (name === 'brandIds') {
+      if (form.brandIds.length === 0) {
+        nextErrors.brandIds = 'Select at least one brand';
+      }
+    }
+
+    setErrors(nextErrors);
+  };
+
   const validate = () => {
     const nextErrors = {};
+    const normalizedName = form.name.trim();
+    const normalizedEmail = form.email.trim();
+    const normalizedPhone = form.phone.trim();
 
-    if (!form.name.trim()) nextErrors.name = 'Name is required';
-    if (!form.email.trim()) nextErrors.email = 'Email is required';
-    if (!form.password) nextErrors.password = 'Password is required';
-    if (form.password !== form.confirmPassword) nextErrors.confirmPassword = 'Passwords do not match';
+    if (!normalizedName) {
+      nextErrors.name = 'Name is required';
+    } else if (normalizedName.length < 2 || normalizedName.length > 100) {
+      nextErrors.name = 'Name must be between 2 and 100 characters';
+    }
+
+    if (!isEditMode) {
+      if (!normalizedEmail) {
+        nextErrors.email = 'Email is required';
+      } else if (!isEmailValid) {
+        nextErrors.email = 'Enter a valid email address';
+      }
+
+      if (!form.password) {
+        nextErrors.password = 'Password is required';
+      } else if (!isPasswordStrong) {
+        nextErrors.password = 'Password does not meet all requirements';
+      }
+
+      if (!form.confirmPassword) {
+        nextErrors.confirmPassword = 'Confirm password is required';
+      } else if (form.password !== form.confirmPassword) {
+        nextErrors.confirmPassword = 'Passwords do not match';
+      }
+    }
+
+    if (normalizedPhone && !/^\d{10,15}$/.test(normalizedPhone)) {
+      nextErrors.phone = 'Phone must be 10-15 digits';
+    }
+
     if (form.brandIds.length === 0) nextErrors.brandIds = 'Select at least one brand';
 
     setErrors(nextErrors);
@@ -53,6 +165,15 @@ export default function CreateSupplierModal({ brands, onClose, onSubmit, isSubmi
     event.preventDefault();
     if (!validate()) return;
 
+    if (isEditMode) {
+      onSubmit({
+        name: form.name.trim(),
+        phone: form.phone.trim() || null,
+        brandIds: form.brandIds,
+      });
+      return;
+    }
+
     onSubmit({
       name: form.name.trim(),
       email: form.email.trim(),
@@ -62,82 +183,131 @@ export default function CreateSupplierModal({ brands, onClose, onSubmit, isSubmi
     });
   };
 
+  const passwordStrengthCount = PASSWORD_RULES.filter((rule) => rule.test(form.password)).length;
+
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 p-4 flex items-center justify-center">
-      <div className="bg-white rounded-lg shadow-xl max-w-lg w-full">
-        <div className="px-6 py-4 border-b">
-          <h2 className="text-xl font-bold text-gray-900">Create Supplier Account</h2>
-          <p className="text-sm text-gray-500 mt-1">Assign one or more brands during onboarding</p>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white shadow-2xl">
+        <div className="border-b border-slate-200 px-6 py-4">
+          <h2 className="text-xl font-bold text-slate-900">
+            {isEditMode ? 'Edit Supplier Account' : 'Create Supplier Account'}
+          </h2>
+          <p className="mt-1 text-sm text-slate-600">
+            {isEditMode
+              ? 'Update supplier details and assigned brands.'
+              : 'Create supplier access and assign one or more brands.'}
+          </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4 px-6 py-5">
+          {apiError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {apiError}
+            </div>
+          )}
+
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Name</label>
             <input
               name="name"
               value={form.name}
               onChange={handleChange}
-              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              onBlur={() => validateField('name')}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
             />
             {errors.name && <p className="text-xs text-red-600 mt-1">{errors.name}</p>}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Email</label>
             <input
               type="email"
               name="email"
               value={form.email}
               onChange={handleChange}
-              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              onBlur={() => validateField('email')}
+              disabled={isEditMode}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200 disabled:cursor-not-allowed disabled:bg-slate-100"
             />
             {errors.email && <p className="text-xs text-red-600 mt-1">{errors.email}</p>}
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-              <input
-                type="password"
-                name="password"
-                value={form.password}
-                onChange={handleChange}
-                className="w-full border border-gray-300 rounded-md px-3 py-2"
-              />
-              {errors.password && <p className="text-xs text-red-600 mt-1">{errors.password}</p>}
+          {!isEditMode && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">Password</label>
+                <input
+                  type="password"
+                  name="password"
+                  value={form.password}
+                  onChange={handleChange}
+                  onBlur={() => validateField('password')}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
+                />
+                {errors.password && <p className="text-xs text-red-600 mt-1">{errors.password}</p>}
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">Confirm Password</label>
+                <input
+                  type="password"
+                  name="confirmPassword"
+                  value={form.confirmPassword}
+                  onChange={handleChange}
+                  onBlur={() => validateField('confirmPassword')}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
+                />
+                {errors.confirmPassword && <p className="text-xs text-red-600 mt-1">{errors.confirmPassword}</p>}
+              </div>
+
+              {form.password.length > 0 && (
+                <div className="sm:col-span-2">
+                  <div className="mb-1 flex gap-1">
+                    {PASSWORD_RULES.map((_, index) => (
+                      <div
+                        key={index}
+                        className={`h-1 flex-1 rounded ${
+                          index < passwordStrengthCount ? 'bg-green-500' : 'bg-slate-200'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+                    {PASSWORD_RULES.map((rule) => (
+                      <p
+                        key={rule.label}
+                        className={rule.test(form.password) ? 'text-green-600' : 'text-slate-500'}
+                      >
+                        {rule.test(form.password) ? '✓' : '○'} {rule.label}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Confirm Password</label>
-              <input
-                type="password"
-                name="confirmPassword"
-                value={form.confirmPassword}
-                onChange={handleChange}
-                className="w-full border border-gray-300 rounded-md px-3 py-2"
-              />
-              {errors.confirmPassword && <p className="text-xs text-red-600 mt-1">{errors.confirmPassword}</p>}
-            </div>
-          </div>
+          )}
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Phone (optional)</label>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Phone (optional)</label>
             <input
               name="phone"
               value={form.phone}
               onChange={handleChange}
-              className="w-full border border-gray-300 rounded-md px-3 py-2"
+              onBlur={() => validateField('phone')}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
             />
+            {errors.phone && <p className="mt-1 text-xs text-red-600">{errors.phone}</p>}
           </div>
 
           <div>
-            <p className="text-sm font-medium text-gray-700 mb-2">Assign Brands</p>
-            <div className="max-h-40 overflow-y-auto border rounded-md p-2 space-y-2">
+            <p className="mb-2 text-sm font-medium text-slate-700">Assign Brands</p>
+            <div className="max-h-44 space-y-2 overflow-y-auto rounded-lg border border-slate-300 p-3">
               {brands.map((brand) => (
-                <label key={brand.id} className="flex items-center gap-2 text-sm text-gray-800">
+                <label key={brand.id} className="flex items-center gap-2 text-sm text-slate-800">
                   <input
                     type="checkbox"
                     checked={form.brandIds.includes(brand.id)}
                     onChange={() => handleBrandToggle(brand.id)}
+                    onBlur={() => validateField('brandIds')}
                   />
                   <span>{brand.name}</span>
                 </label>
@@ -149,26 +319,31 @@ export default function CreateSupplierModal({ brands, onClose, onSubmit, isSubmi
               </p>
             )}
           </div>
-        </form>
 
-        <div className="px-6 py-4 border-t bg-gray-50 flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isSubmitting}
-            className="px-4 py-2 rounded-md bg-gray-200 text-gray-700"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={isSubmitting || brands.length === 0}
-            className="px-4 py-2 rounded-md bg-green-600 text-white disabled:opacity-60"
-          >
-            {isSubmitting ? 'Creating...' : 'Create Supplier'}
-          </button>
-        </div>
+          <div className="flex justify-end gap-2 border-t border-slate-200 bg-slate-50 px-6 py-4 -mx-6 -mb-5 mt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="rounded-lg bg-slate-200 px-4 py-2 text-sm font-medium text-slate-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || brands.length === 0 || !isFormValid}
+              className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting
+                ? isEditMode
+                  ? 'Saving...'
+                  : 'Creating...'
+                : isEditMode
+                  ? 'Save Changes'
+                  : 'Create Supplier'}
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/frontend/src/components/admin/ProductFormModal.jsx
+++ b/frontend/src/components/admin/ProductFormModal.jsx
@@ -10,11 +10,12 @@ const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
  * otherwise it starts empty (create mode).
  *
  * @param {Object|null} product   - existing product to edit, or null for create
+ * @param {Array}       brands    - active brands for optional assignment
  * @param {Function}    onSubmit  - called with form data object on save
  * @param {Function}    onClose   - called when the modal should close
  * @param {boolean}     loading   - disables the submit button while saving
  */
-export default function ProductFormModal({ product, onSubmit, onClose, loading }) {
+export default function ProductFormModal({ product, brands, onSubmit, onClose, loading }) {
   const isEdit = product !== null && product !== undefined;
 
   const [form, setForm] = useState({
@@ -24,6 +25,7 @@ export default function ProductFormModal({ product, onSubmit, onClose, loading }
     category: '',
     unit: 'PER_ITEM',
     imageUrl: '',
+    brandId: '',
     featured: false,
     expiryDate: '',
     stockQuantity: '',
@@ -47,6 +49,7 @@ export default function ProductFormModal({ product, onSubmit, onClose, loading }
         category: product.category ?? '',
         unit: product.unit ?? 'PER_ITEM',
         imageUrl: product.imageUrl ?? '',
+        brandId: product.brandId ?? '',
         featured: product.featured ?? false,
         expiryDate: product.expiryDate ?? '',
         stockQuantity: product.stockQuantity ?? '',
@@ -126,6 +129,7 @@ export default function ProductFormModal({ product, onSubmit, onClose, loading }
       description: ((form.description ?? '').trim()) || null,
       price: Number.isFinite(priceVal) ? priceVal : 0,
       category: ((form.category ?? '').trim()) || null,
+      brandId: form.brandId ? Number(form.brandId) : null,
       unit: form.unit || 'PER_ITEM',
       imageUrl: resolvedImageUrl,
       featured: !!form.featured,
@@ -140,7 +144,7 @@ export default function ProductFormModal({ product, onSubmit, onClose, loading }
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 px-4 py-6 overflow-y-auto">
       <div className="w-full max-w-lg bg-white rounded-2xl shadow-xl flex flex-col max-h-[90vh] my-auto">
         {/* Sticky header */}
-        <div className="px-6 pt-6 pb-2 flex-shrink-0">
+        <div className="px-6 pt-6 pb-2 shrink-0">
           <h2 className="text-lg font-bold text-gray-800">
             {isEdit ? 'Edit Product' : 'Add Product'}
           </h2>
@@ -214,6 +218,23 @@ export default function ProductFormModal({ product, onSubmit, onClose, loading }
               className={inputCls}
               placeholder="e.g. Dairy"
             />
+          </Field>
+
+          {/* Optional Brand */}
+          <Field label="Brand (optional)">
+            <select
+              name="brandId"
+              value={form.brandId}
+              onChange={handleChange}
+              className={inputCls}
+            >
+              <option value="">No Brand</option>
+              {brands?.map((brand) => (
+                <option key={brand.id} value={brand.id}>
+                  {brand.name} ({brand.code})
+                </option>
+              ))}
+            </select>
           </Field>
 
           {/* Pricing Unit */}

--- a/frontend/src/pages/admin/AdminBrandsPage.jsx
+++ b/frontend/src/pages/admin/AdminBrandsPage.jsx
@@ -1,0 +1,311 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
+import {
+  createBrand,
+  deleteBrand,
+  getAllBrands,
+  updateBrand,
+} from '../../services/adminBrandService';
+
+/**
+ * Presentation Layer – Admin brand management page.
+ */
+export default function AdminBrandsPage() {
+  const navigate = useNavigate();
+  const [brands, setBrands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [editingBrand, setEditingBrand] = useState(null);
+  const [serverError, setServerError] = useState('');
+
+  const [form, setForm] = useState({ name: '', code: '' });
+  const [errors, setErrors] = useState({});
+
+  const isEditMode = Boolean(editingBrand);
+
+  useEffect(() => {
+    loadBrands();
+  }, []);
+
+  const loadBrands = async () => {
+    setLoading(true);
+    try {
+      const data = await getAllBrands();
+      setBrands(data);
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to load brands';
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const activeCount = useMemo(
+    () => brands.filter((brand) => brand.active).length,
+    [brands],
+  );
+
+  const openCreate = () => {
+    setEditingBrand(null);
+    setForm({ name: '', code: '' });
+    setErrors({});
+    setServerError('');
+    setShowModal(true);
+  };
+
+  const openEdit = (brand) => {
+    setEditingBrand(brand);
+    setForm({ name: brand.name || '', code: brand.code || '' });
+    setErrors({});
+    setServerError('');
+    setShowModal(true);
+  };
+
+  const closeModal = () => {
+    setShowModal(false);
+    setEditingBrand(null);
+    setServerError('');
+    setErrors({});
+  };
+
+  const validate = () => {
+    const nextErrors = {};
+    const normalizedName = form.name.trim();
+    const normalizedCode = form.code.trim().toUpperCase();
+
+    if (!normalizedName) {
+      nextErrors.name = 'Brand name is required';
+    } else if (normalizedName.length > 120) {
+      nextErrors.name = 'Brand name must not exceed 120 characters';
+    }
+
+    if (!normalizedCode) {
+      nextErrors.code = 'Brand code is required';
+    } else if (!/^[A-Z0-9_-]{2,60}$/.test(normalizedCode)) {
+      nextErrors.code = 'Use 2-60 uppercase letters, numbers, underscore, or hyphen';
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setServerError('');
+
+    if (!validate()) {
+      return;
+    }
+
+    const payload = {
+      name: form.name.trim(),
+      code: form.code.trim().toUpperCase(),
+    };
+
+    setSaving(true);
+    try {
+      if (isEditMode) {
+        await updateBrand(editingBrand.id, payload);
+        toast.success('Brand updated successfully');
+      } else {
+        await createBrand(payload);
+        toast.success('Brand created successfully');
+      }
+      closeModal();
+      await loadBrands();
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to save brand';
+      if (error.response?.status === 409) {
+        setServerError(message);
+      } else {
+        toast.error(message);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeactivate = async (brand) => {
+    if (!brand.active) {
+      return;
+    }
+
+    try {
+      await deleteBrand(brand.id);
+      toast.success('Brand deactivated successfully');
+      await loadBrands();
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to deactivate brand';
+      toast.error(message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <button
+          onClick={() => navigate('/admin')}
+          className="mb-4 inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-green-700"
+        >
+          <span aria-hidden="true">&larr;</span>
+          <span>Back to Dashboard</span>
+        </button>
+
+        <div className="rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+          <div className="flex flex-col gap-4 border-b border-slate-200 pb-6 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-green-600">Admin Panel</p>
+              <h1 className="mt-1 text-3xl font-bold text-slate-900">Brand Management</h1>
+              <p className="mt-2 max-w-xl text-sm text-slate-600">
+                Manage product brands used for supplier ownership and product categorization.
+              </p>
+            </div>
+            <button
+              onClick={openCreate}
+              className="inline-flex items-center justify-center rounded-xl bg-green-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
+            >
+              + Create Brand
+            </button>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="rounded-xl bg-slate-100 px-4 py-3">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Total Brands</p>
+              <p className="mt-1 text-2xl font-bold text-slate-800">{brands.length}</p>
+            </div>
+            <div className="rounded-xl bg-green-50 px-4 py-3">
+              <p className="text-xs uppercase tracking-wide text-green-700">Active Brands</p>
+              <p className="mt-1 text-2xl font-bold text-green-700">{activeCount}</p>
+            </div>
+          </div>
+
+          <div className="mt-6 overflow-hidden rounded-xl border border-slate-200">
+            {loading ? (
+              <div className="p-8 text-center text-sm text-slate-500">Loading brands...</div>
+            ) : brands.length === 0 ? (
+              <div className="p-8 text-center text-sm text-slate-500">No brands found. Create your first brand.</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
+                    <tr>
+                      <th className="px-4 py-3 text-left">Name</th>
+                      <th className="px-4 py-3 text-left">Code</th>
+                      <th className="px-4 py-3 text-left">Status</th>
+                      <th className="px-4 py-3 text-left">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {brands.map((brand) => (
+                      <tr key={brand.id} className="border-t border-slate-200">
+                        <td className="px-4 py-3 font-medium text-slate-900">{brand.name}</td>
+                        <td className="px-4 py-3 text-slate-700">{brand.code}</td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${
+                              brand.active ? 'bg-green-100 text-green-700' : 'bg-slate-200 text-slate-600'
+                            }`}
+                          >
+                            {brand.active ? 'Active' : 'Inactive'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex gap-3">
+                            <button
+                              onClick={() => openEdit(brand)}
+                              className="text-xs font-semibold text-blue-600 hover:text-blue-700"
+                            >
+                              Edit
+                            </button>
+                            <button
+                              onClick={() => handleDeactivate(brand)}
+                              disabled={!brand.active}
+                              className="text-xs font-semibold text-red-600 hover:text-red-700 disabled:cursor-not-allowed disabled:text-slate-400"
+                            >
+                              Deactivate
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4">
+          <div className="w-full max-w-md rounded-2xl bg-white shadow-2xl">
+            <div className="border-b border-slate-200 px-6 py-4">
+              <h2 className="text-xl font-bold text-slate-900">{isEditMode ? 'Edit Brand' : 'Create Brand'}</h2>
+              <p className="mt-1 text-sm text-slate-600">Keep names and codes unique for clean assignment workflows.</p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4 px-6 py-5">
+              {serverError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {serverError}
+                </div>
+              )}
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">Brand Name</label>
+                <input
+                  name="name"
+                  value={form.name}
+                  onChange={(event) => {
+                    setForm((prev) => ({ ...prev, name: event.target.value }));
+                    if (errors.name) {
+                      setErrors((prev) => ({ ...prev, name: '' }));
+                    }
+                  }}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
+                />
+                {errors.name && <p className="mt-1 text-xs text-red-600">{errors.name}</p>}
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">Brand Code</label>
+                <input
+                  name="code"
+                  value={form.code}
+                  onChange={(event) => {
+                    setForm((prev) => ({ ...prev, code: event.target.value.toUpperCase() }));
+                    if (errors.code) {
+                      setErrors((prev) => ({ ...prev, code: '' }));
+                    }
+                  }}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm uppercase focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-200"
+                />
+                {errors.code && <p className="mt-1 text-xs text-red-600">{errors.code}</p>}
+              </div>
+
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  disabled={saving}
+                  className="rounded-lg bg-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-300 disabled:opacity-60"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-60"
+                >
+                  {saving ? 'Saving...' : isEditMode ? 'Update Brand' : 'Create Brand'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -274,6 +274,17 @@ const AdminDashboard = () => {
                 <p className="text-xs text-gray-400">Create & manage accounts</p>
               </div>
             </Link>
+
+            <Link
+              to="/admin/suppliers"
+              className="flex items-center gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:border-green-400 hover:bg-green-50 transition-colors"
+            >
+              <span className="text-3xl">🏷️</span>
+              <div>
+                <p className="font-semibold text-gray-800">Manage Suppliers</p>
+                <p className="text-xs text-gray-400">Create suppliers and assign brands</p>
+              </div>
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -285,6 +285,17 @@ const AdminDashboard = () => {
                 <p className="text-xs text-gray-400">Create suppliers and assign brands</p>
               </div>
             </Link>
+
+            <Link
+              to="/admin/brands"
+              className="flex items-center gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:border-green-400 hover:bg-green-50 transition-colors"
+            >
+              <span className="text-3xl">🏭</span>
+              <div>
+                <p className="font-semibold text-gray-800">Manage Brands</p>
+                <p className="text-xs text-gray-400">Create, update, and deactivate brands</p>
+              </div>
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/AdminProductsPage.jsx
+++ b/frontend/src/pages/admin/AdminProductsPage.jsx
@@ -7,6 +7,7 @@ import {
   updateProduct,
   deleteProduct,
 } from '../../services/adminProductService';
+import { getActiveBrands } from '../../services/adminBrandService';
 import ProductFormModal from '../../components/admin/ProductFormModal';
 import { formatPrice } from '../../utils/priceUtils';
 
@@ -23,6 +24,7 @@ export default function AdminProductsPage() {
   const [currentPage, setCurrentPage] = useState(0);
   const [loadingTable, setLoadingTable] = useState(false);
   const [tableError, setTableError] = useState(null);
+  const [brands, setBrands] = useState([]);
 
   // ── Modal state ──────────────────────────────────────────────────────────────
   const [modalOpen, setModalOpen] = useState(false);
@@ -37,8 +39,12 @@ export default function AdminProductsPage() {
     setLoadingTable(true);
     setTableError(null);
     try {
-      const data = await getAdminProducts(page, 20);
+      const [data, activeBrands] = await Promise.all([
+        getAdminProducts(page, 20),
+        getActiveBrands(),
+      ]);
       setPageData(data);
+      setBrands(activeBrands);
     } catch {
       setTableError('Failed to load products. Please try again.');
     } finally {
@@ -151,6 +157,7 @@ export default function AdminProductsPage() {
                 <tr>
                   <th className={th}>Name</th>
                   <th className={th}>Category</th>
+                  <th className={th}>Brand</th>
                   <th className={th}>Price</th>
                   <th className={th}>Unit</th>
                   <th className={th}>Stock</th>
@@ -162,7 +169,7 @@ export default function AdminProductsPage() {
               <tbody>
                 {pageData.content?.length === 0 ? (
                   <tr>
-                    <td colSpan={8} className="py-10 text-center text-gray-400">
+                    <td colSpan={9} className="py-10 text-center text-gray-400">
                       No products found. Add one to get started.
                     </td>
                   </tr>
@@ -173,6 +180,7 @@ export default function AdminProductsPage() {
                         <span className="font-medium text-gray-800">{p.name}</span>
                       </td>
                       <td className={td}>{p.category ?? '—'}</td>
+                      <td className={td}>{p.brandName ?? '—'}</td>
                       <td className={td}>{formatPrice(p.price, p.unit)}</td>
                       <td className={td}>{UNIT_DISPLAY[p.unit] ?? p.unit ?? '—'}</td>
                       <td className={td}>
@@ -250,6 +258,7 @@ export default function AdminProductsPage() {
       {modalOpen && (
         <ProductFormModal
           product={editProduct}
+          brands={brands}
           onSubmit={handleSubmit}
           onClose={closeModal}
           loading={saving}

--- a/frontend/src/pages/admin/AdminSuppliersPage.jsx
+++ b/frontend/src/pages/admin/AdminSuppliersPage.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import {
+  createSupplier,
+  getActiveBrands,
+  getSuppliers,
+  updateSupplierStatus,
+} from '../../services/adminSupplierService';
+import CreateSupplierModal from '../../components/admin/CreateSupplierModal';
+
+/**
+ * Presentation Layer – Admin supplier management page.
+ */
+export default function AdminSuppliersPage() {
+  const [suppliers, setSuppliers] = useState([]);
+  const [brands, setBrands] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const [supplierData, brandData] = await Promise.all([
+        getSuppliers(),
+        getActiveBrands(),
+      ]);
+      setSuppliers(supplierData);
+      setBrands(brandData);
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to load supplier management data';
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateSupplier = async (payload) => {
+    setIsSubmitting(true);
+    try {
+      await createSupplier(payload);
+      toast.success('Supplier account created successfully');
+      setShowCreateModal(false);
+      await loadData();
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to create supplier account';
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleToggleStatus = async (supplier) => {
+    try {
+      const nextStatus = !supplier.isActive;
+      await updateSupplierStatus(supplier.id, nextStatus);
+      toast.success(`Supplier ${nextStatus ? 'activated' : 'deactivated'} successfully`);
+      await loadData();
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to update supplier status';
+      toast.error(message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Supplier Management</h1>
+            <p className="text-sm text-gray-600 mt-1">Create supplier accounts and assign brand ownership</p>
+          </div>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="bg-green-600 text-white px-5 py-2 rounded-md hover:bg-green-700"
+          >
+            + Create Supplier
+          </button>
+        </div>
+
+        {showCreateModal && (
+          <CreateSupplierModal
+            brands={brands}
+            onClose={() => setShowCreateModal(false)}
+            onSubmit={handleCreateSupplier}
+            isSubmitting={isSubmitting}
+          />
+        )}
+
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          {loading ? (
+            <div className="p-10 text-center text-gray-500">Loading supplier accounts...</div>
+          ) : suppliers.length === 0 ? (
+            <div className="p-10 text-center text-gray-500">No suppliers found. Create one to get started.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-gray-600 uppercase tracking-wide text-xs">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Name</th>
+                    <th className="px-4 py-3 text-left">Email</th>
+                    <th className="px-4 py-3 text-left">Brands</th>
+                    <th className="px-4 py-3 text-left">Status</th>
+                    <th className="px-4 py-3 text-left">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {suppliers.map((supplier) => (
+                    <tr key={supplier.id} className="border-t border-gray-100">
+                      <td className="px-4 py-3 font-medium text-gray-900">{supplier.name}</td>
+                      <td className="px-4 py-3 text-gray-700">{supplier.email}</td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {supplier.brands?.length
+                          ? supplier.brands.map((brand) => brand.name).join(', ')
+                          : 'No brands assigned'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex px-2 py-1 rounded-full text-xs font-semibold ${
+                            supplier.isActive ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                          }`}
+                        >
+                          {supplier.isActive ? 'Active' : 'Inactive'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => handleToggleStatus(supplier)}
+                          className={`px-3 py-1.5 text-xs rounded-md text-white ${
+                            supplier.isActive ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'
+                          }`}
+                        >
+                          {supplier.isActive ? 'Deactivate' : 'Activate'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminSuppliersPage.jsx
+++ b/frontend/src/pages/admin/AdminSuppliersPage.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 import {
   createSupplier,
   getActiveBrands,
   getSuppliers,
+  updateSupplier,
   updateSupplierStatus,
 } from '../../services/adminSupplierService';
 import CreateSupplierModal from '../../components/admin/CreateSupplierModal';
@@ -12,11 +14,14 @@ import CreateSupplierModal from '../../components/admin/CreateSupplierModal';
  * Presentation Layer – Admin supplier management page.
  */
 export default function AdminSuppliersPage() {
+  const navigate = useNavigate();
   const [suppliers, setSuppliers] = useState([]);
   const [brands, setBrands] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [editingSupplier, setEditingSupplier] = useState(null);
+  const [modalError, setModalError] = useState('');
 
   useEffect(() => {
     loadData();
@@ -41,17 +46,66 @@ export default function AdminSuppliersPage() {
 
   const handleCreateSupplier = async (payload) => {
     setIsSubmitting(true);
+    setModalError('');
     try {
       await createSupplier(payload);
       toast.success('Supplier account created successfully');
       setShowCreateModal(false);
+      setEditingSupplier(null);
       await loadData();
     } catch (error) {
       const message = error.response?.data?.message || 'Failed to create supplier account';
-      toast.error(message);
+      if (error.response?.status === 409) {
+        setModalError(message);
+      } else {
+        toast.error(message);
+      }
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleUpdateSupplier = async (payload) => {
+    if (!editingSupplier) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setModalError('');
+    try {
+      await updateSupplier(editingSupplier.id, payload);
+      toast.success('Supplier updated successfully');
+      setShowCreateModal(false);
+      setEditingSupplier(null);
+      await loadData();
+    } catch (error) {
+      const message = error.response?.data?.message || 'Failed to update supplier';
+      if (error.response?.status === 409) {
+        setModalError(message);
+      } else {
+        toast.error(message);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const openCreateModal = () => {
+    setEditingSupplier(null);
+    setModalError('');
+    setShowCreateModal(true);
+  };
+
+  const openEditModal = (supplier) => {
+    setEditingSupplier(supplier);
+    setModalError('');
+    setShowCreateModal(true);
+  };
+
+  const closeModal = () => {
+    setShowCreateModal(false);
+    setEditingSupplier(null);
+    setModalError('');
   };
 
   const handleToggleStatus = async (supplier) => {
@@ -67,39 +121,71 @@ export default function AdminSuppliersPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
-      <div className="max-w-7xl mx-auto">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900">Supplier Management</h1>
-            <p className="text-sm text-gray-600 mt-1">Create supplier accounts and assign brand ownership</p>
+    <div className="min-h-screen bg-slate-50 px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <button
+          onClick={() => navigate('/admin')}
+          className="mb-4 inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition hover:text-green-700"
+        >
+          <span aria-hidden="true">&larr;</span>
+          <span>Back to Dashboard</span>
+        </button>
+
+        <div className="mb-6 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200 sm:p-8">
+          <div className="flex flex-col gap-4 border-b border-slate-200 pb-6 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-green-600">Admin Panel</p>
+              <h1 className="mt-1 text-3xl font-bold text-slate-900">Supplier Management</h1>
+              <p className="mt-2 max-w-2xl text-sm text-slate-600">
+                Create supplier accounts, keep profiles updated, and control brand ownership with clear validation.
+              </p>
+            </div>
+            <button
+              onClick={openCreateModal}
+              className="inline-flex items-center justify-center rounded-xl bg-green-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-green-700"
+            >
+              + Create Supplier
+            </button>
           </div>
-          <button
-            onClick={() => setShowCreateModal(true)}
-            className="bg-green-600 text-white px-5 py-2 rounded-md hover:bg-green-700"
-          >
-            + Create Supplier
-          </button>
+
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="rounded-xl bg-slate-100 px-4 py-3">
+              <p className="text-xs uppercase tracking-wide text-slate-500">Total Suppliers</p>
+              <p className="mt-1 text-2xl font-bold text-slate-800">{suppliers.length}</p>
+            </div>
+            <div className="rounded-xl bg-green-50 px-4 py-3">
+              <p className="text-xs uppercase tracking-wide text-green-700">Active Suppliers</p>
+              <p className="mt-1 text-2xl font-bold text-green-700">
+                {suppliers.filter((supplier) => supplier.isActive).length}
+              </p>
+            </div>
+            <div className="rounded-xl bg-blue-50 px-4 py-3">
+              <p className="text-xs uppercase tracking-wide text-blue-700">Active Brands Available</p>
+              <p className="mt-1 text-2xl font-bold text-blue-700">{brands.length}</p>
+            </div>
+          </div>
         </div>
 
         {showCreateModal && (
           <CreateSupplierModal
             brands={brands}
-            onClose={() => setShowCreateModal(false)}
-            onSubmit={handleCreateSupplier}
+            initialSupplier={editingSupplier}
+            apiError={modalError}
+            onClose={closeModal}
+            onSubmit={editingSupplier ? handleUpdateSupplier : handleCreateSupplier}
             isSubmitting={isSubmitting}
           />
         )}
 
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-slate-200">
           {loading ? (
-            <div className="p-10 text-center text-gray-500">Loading supplier accounts...</div>
+            <div className="p-10 text-center text-slate-500">Loading supplier accounts...</div>
           ) : suppliers.length === 0 ? (
-            <div className="p-10 text-center text-gray-500">No suppliers found. Create one to get started.</div>
+            <div className="p-10 text-center text-slate-500">No suppliers found. Create one to get started.</div>
           ) : (
             <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead className="bg-gray-50 text-gray-600 uppercase tracking-wide text-xs">
+              <table className="min-w-full text-sm">
+                <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-600">
                   <tr>
                     <th className="px-4 py-3 text-left">Name</th>
                     <th className="px-4 py-3 text-left">Email</th>
@@ -110,17 +196,17 @@ export default function AdminSuppliersPage() {
                 </thead>
                 <tbody>
                   {suppliers.map((supplier) => (
-                    <tr key={supplier.id} className="border-t border-gray-100">
-                      <td className="px-4 py-3 font-medium text-gray-900">{supplier.name}</td>
-                      <td className="px-4 py-3 text-gray-700">{supplier.email}</td>
-                      <td className="px-4 py-3 text-gray-700">
+                    <tr key={supplier.id} className="border-t border-slate-200">
+                      <td className="px-4 py-3 font-medium text-slate-900">{supplier.name}</td>
+                      <td className="px-4 py-3 text-slate-700">{supplier.email}</td>
+                      <td className="px-4 py-3 text-slate-700">
                         {supplier.brands?.length
                           ? supplier.brands.map((brand) => brand.name).join(', ')
                           : 'No brands assigned'}
                       </td>
                       <td className="px-4 py-3">
                         <span
-                          className={`inline-flex px-2 py-1 rounded-full text-xs font-semibold ${
+                          className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${
                             supplier.isActive ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
                           }`}
                         >
@@ -128,14 +214,22 @@ export default function AdminSuppliersPage() {
                         </span>
                       </td>
                       <td className="px-4 py-3">
-                        <button
-                          onClick={() => handleToggleStatus(supplier)}
-                          className={`px-3 py-1.5 text-xs rounded-md text-white ${
-                            supplier.isActive ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'
-                          }`}
-                        >
-                          {supplier.isActive ? 'Deactivate' : 'Activate'}
-                        </button>
+                        <div className="flex gap-3">
+                          <button
+                            onClick={() => openEditModal(supplier)}
+                            className="text-xs font-semibold text-blue-600 hover:text-blue-700"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => handleToggleStatus(supplier)}
+                            className={`text-xs font-semibold ${
+                              supplier.isActive ? 'text-red-600 hover:text-red-700' : 'text-green-600 hover:text-green-700'
+                            }`}
+                          >
+                            {supplier.isActive ? 'Deactivate' : 'Activate'}
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/pages/auth/LoginPage.jsx
+++ b/frontend/src/pages/auth/LoginPage.jsx
@@ -79,6 +79,8 @@ export default function LoginPage() {
 
       if (status === 401) {
         setError(message || 'Invalid email or password');
+      } else if (status === 403) {
+        setError(message || 'Access denied for this account');
       } else if (status === 400) {
         setError(message || 'Please fill in all fields correctly');
       } else {

--- a/frontend/src/pages/supplier/SupplierDashboard.jsx
+++ b/frontend/src/pages/supplier/SupplierDashboard.jsx
@@ -1,14 +1,39 @@
+import { useEffect, useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
+import { getSupplierBrands, getSupplierProducts } from '../../services/supplierService';
+import { formatPrice } from '../../utils/priceUtils';
 
 /**
- * Presentation Layer – Supplier dashboard placeholder.
- * Full implementation in later sprints (product uploads, shipments).
+ * Presentation Layer – Supplier dashboard scoped by assigned brand ownership.
  */
 export default function SupplierDashboard() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const [products, setProducts] = useState([]);
+  const [brands, setBrands] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadSupplierData = async () => {
+    setLoading(true);
+    try {
+      const [productData, brandData] = await Promise.all([
+        getSupplierProducts(),
+        getSupplierBrands(),
+      ]);
+      setProducts(productData);
+      setBrands(brandData);
+    } catch {
+      toast.error('Failed to load supplier catalog');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSupplierData();
+  }, []);
 
   const handleLogout = () => {
     logout();
@@ -18,7 +43,7 @@ export default function SupplierDashboard() {
 
   return (
     <div className="min-h-screen bg-blue-50 p-8">
-      <div className="max-w-2xl mx-auto bg-white rounded-2xl shadow-md p-8">
+      <div className="max-w-5xl mx-auto bg-white rounded-2xl shadow-md p-8">
         <div className="flex justify-between items-center mb-6">
           <h1 className="text-2xl font-bold text-green-700">UrbanFresh Supplier</h1>
           <button
@@ -31,10 +56,54 @@ export default function SupplierDashboard() {
         <p className="text-gray-600">
           Welcome, <span className="font-semibold">{user?.name}</span> (Supplier)
         </p>
-        <p className="text-gray-400 text-sm mt-2">
-          Supplier portal coming in upcoming sprints.
-        </p>
+
+        <div className="mt-4 p-3 rounded-lg border border-gray-200 bg-gray-50">
+          <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Assigned Brands</p>
+          {brands.length === 0 ? (
+            <p className="text-sm text-amber-700">No brands assigned yet. Contact an administrator.</p>
+          ) : (
+            <p className="text-sm text-gray-700">{brands.map((brand) => brand.name).join(', ')}</p>
+          )}
+        </div>
+
+        <div className="mt-6">
+          <h2 className="text-lg font-semibold text-gray-800 mb-3">Products You Can Manage</h2>
+
+          {loading ? (
+            <p className="text-sm text-gray-500">Loading products...</p>
+          ) : products.length === 0 ? (
+            <p className="text-sm text-gray-500">No products available for your assigned brand(s).</p>
+          ) : (
+            <div className="overflow-x-auto border border-gray-200 rounded-xl">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                  <tr>
+                    <th className={th}>Product</th>
+                    <th className={th}>Brand</th>
+                    <th className={th}>Category</th>
+                    <th className={th}>Price</th>
+                    <th className={th}>Stock</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {products.map((product) => (
+                    <tr key={product.id} className="border-t border-gray-100">
+                      <td className={td}>{product.name}</td>
+                      <td className={td}>{product.brandName || '—'}</td>
+                      <td className={td}>{product.category || '—'}</td>
+                      <td className={td}>{formatPrice(product.price, product.unit)}</td>
+                      <td className={td}>{product.stockQuantity}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
 }
+
+const th = 'px-4 py-3 text-left';
+const td = 'px-4 py-3 text-gray-700';

--- a/frontend/src/services/adminBrandService.js
+++ b/frontend/src/services/adminBrandService.js
@@ -1,0 +1,49 @@
+import api from './api';
+
+/**
+ * Service Layer – Admin brand management API calls.
+ */
+
+/**
+ * Returns active brands for assignment pickers.
+ *
+ * @returns {Promise<Array>} active brands
+ */
+export const getActiveBrands = () =>
+  api.get('/api/admin/brands').then((res) => res.data);
+
+/**
+ * Returns all brands including inactive rows for management views.
+ *
+ * @returns {Promise<Array>} all brands
+ */
+export const getAllBrands = () =>
+  api.get('/api/admin/brands/all').then((res) => res.data);
+
+/**
+ * Creates a new brand.
+ *
+ * @param {{name: string, code: string}} payload brand create payload
+ * @returns {Promise<Object>} created brand
+ */
+export const createBrand = (payload) =>
+  api.post('/api/admin/brands', payload).then((res) => res.data);
+
+/**
+ * Updates an existing brand.
+ *
+ * @param {number} brandId brand ID
+ * @param {{name: string, code: string}} payload brand update payload
+ * @returns {Promise<Object>} updated brand
+ */
+export const updateBrand = (brandId, payload) =>
+  api.put(`/api/admin/brands/${brandId}`, payload).then((res) => res.data);
+
+/**
+ * Soft deletes a brand (marks as inactive).
+ *
+ * @param {number} brandId brand ID
+ * @returns {Promise<void>}
+ */
+export const deleteBrand = (brandId) =>
+  api.delete(`/api/admin/brands/${brandId}`).then((res) => res.data);

--- a/frontend/src/services/adminSupplierService.js
+++ b/frontend/src/services/adminSupplierService.js
@@ -1,0 +1,38 @@
+import api from './api';
+
+/**
+ * Service Layer – Admin supplier management API calls.
+ */
+
+/**
+ * Fetch all supplier accounts.
+ *
+ * @returns {Promise<Array>} supplier list
+ */
+export const getSuppliers = () => api.get('/api/admin/suppliers').then((res) => res.data);
+
+/**
+ * Fetch active brands for assignment forms.
+ *
+ * @returns {Promise<Array>} active brands
+ */
+export const getActiveBrands = () => api.get('/api/admin/brands').then((res) => res.data);
+
+/**
+ * Create a supplier account with brand assignment.
+ *
+ * @param {Object} payload create supplier payload
+ * @returns {Promise<Object>} created supplier
+ */
+export const createSupplier = (payload) =>
+  api.post('/api/admin/suppliers', payload).then((res) => res.data);
+
+/**
+ * Toggle supplier account status.
+ *
+ * @param {number} supplierId supplier user id
+ * @param {boolean} isActive true to activate, false to deactivate
+ * @returns {Promise<Object>} updated supplier
+ */
+export const updateSupplierStatus = (supplierId, isActive) =>
+  api.patch(`/api/admin/suppliers/${supplierId}/status`, { isActive }).then((res) => res.data);

--- a/frontend/src/services/adminSupplierService.js
+++ b/frontend/src/services/adminSupplierService.js
@@ -28,6 +28,16 @@ export const createSupplier = (payload) =>
   api.post('/api/admin/suppliers', payload).then((res) => res.data);
 
 /**
+ * Update supplier profile and assigned brands.
+ *
+ * @param {number} supplierId supplier user id
+ * @param {Object} payload supplier update payload
+ * @returns {Promise<Object>} updated supplier
+ */
+export const updateSupplier = (supplierId, payload) =>
+  api.put(`/api/admin/suppliers/${supplierId}`, payload).then((res) => res.data);
+
+/**
  * Toggle supplier account status.
  *
  * @param {number} supplierId supplier user id

--- a/frontend/src/services/supplierService.js
+++ b/frontend/src/services/supplierService.js
@@ -1,0 +1,21 @@
+import api from './api';
+
+/**
+ * Service Layer – Supplier-scoped API calls.
+ */
+
+/**
+ * Returns brands assigned to the authenticated supplier.
+ *
+ * @returns {Promise<Array>} array of BrandResponse
+ */
+export const getSupplierBrands = () =>
+  api.get('/api/supplier/brands').then((res) => res.data);
+
+/**
+ * Returns products scoped to supplier assigned brands.
+ *
+ * @returns {Promise<Array>} array of SupplierProductResponse
+ */
+export const getSupplierProducts = () =>
+  api.get('/api/supplier/products').then((res) => res.data);


### PR DESCRIPTION
**JIRA:** SCRUM-29

## Summary
- Implemented admin dashboard enhancements to streamline supplier onboarding and brand management. Added brand CRUD with soft-deactivate, transactional supplier-brand assignment, clearer backend validation and consistent API error handling, and improved admin UI/UX for brands, suppliers, and products. These changes enforce brand-scoped product ownership, prevent unauthorized supplier access, and improve admin productivity.

## What changed (high-level)
- Backend:
  - Added brand CRUD endpoints and admin supplier update endpoint that performs transactional replacement of supplier-brand assignments and validates brands are active.
  - Introduced `BrandConflictException` and `BrandNotFoundException`, standardized duplicate-email messaging, and updated the global exception handler for consistent API responses.
  - Repository helpers added for case-insensitive uniqueness checks and brand queries.
- Frontend:
  - Added `AdminBrandsPage` with create/edit modals and soft-deactivate actions; wired route into the admin dashboard.
  - Enhanced `CreateSupplierModal` with stronger client-side validation, password strength feedback, inline server errors, and brand-assignment UI.
  - Added optional brand selector to admin product form and surfaced brand metadata in product lists. Improved state handling to reduce redundant fetches.
- Tests:
  - Unit tests added for brand CRUD behavior and supplier-brand replacement logic at the service layer.
  - Manual smoke verification: backend unit tests and frontend production build passed.
- Security:
  - RBAC and JWT protections preserved; brand scoping enforced at the service layer to prevent unauthorized product access.

## Reasons
- Business justification: ensures suppliers are provisioned with explicit brand ownership so they only manage their brand's products, reducing operational risk and enforcing onboarding rules.
- The changes satisfy acceptance criteria by providing supplier creation with brand assignment, enforcing brand-scoped product visibility, and preventing deactivated suppliers from authenticating.

## Steps to Reproduce (Before)
1. Admin lacked centralized brand management; assigning brands during supplier creation required ad-hoc steps.
2. Supplier accounts could be created without enforced brand mapping, allowing access to products outside intended scope.
3. API error messages were inconsistent, making client-side handling fragile.

## Expected Behaviour (After)
- Admins can create/edit/soft-deactivate brands via the Admin Brands page; active brands are available for assignment during supplier creation/edit.
- Suppliers created/updated with assigned brands can authenticate and only see products linked to their assigned brands.
- Deactivated suppliers cannot authenticate and receive a clear access-denied message.
- API returns consistent HTTP status codes: 201 for creates, 200 for updates, 404 for not found, 409 for conflicts, 400 for validation errors.

## Implementation Details

### Backend
- Controllers:
  - `POST /api/admin/brands` — create brand (name/code validation).
  - `PUT /api/admin/brands/{id}` — update brand with conflict checks.
  - `DELETE /api/admin/brands/{id}` — soft-deactivate brand (`active=false`).
  - `GET /api/admin/brands` — list active brands for forms.
  - `GET /api/admin/brands/all` — admin view including inactive brands.
  - `PUT /api/admin/suppliers/{id}` — update supplier profile and assigned brands transactionally.
- Services:
  - `AdminServiceImpl` validates uniqueness, loads/validates active brands, and performs transactional replacement of supplier-brand relationships.
  - `AdminProductServiceImpl` resolves optional `brandId` and maps brand metadata into responses.
- DTOs:
  - `BrandRequest` added for brand create/update validation.
  - `UpdateSupplierRequest` added to accept supplier fields and `brandIds`.
  - Product request/response extended with optional `brandId` and brand metadata.
- Error handling:
  - Added `BrandConflictException`, `BrandNotFoundException`, standardized `DuplicateEmailException`, and updated `GlobalExceptionHandler` for structured responses.

### Frontend
- Pages/Components:
  - `AdminBrandsPage.jsx` — new brand management UI with create/edit/deactivate capabilities.
  - `CreateSupplierModal.jsx` — stronger validation, password-strength UI, inline server error zone, and brand assignment checkboxes.
  - `ProductFormModal.jsx` — optional brand selector integrated into product payload.
  - `AdminSuppliersPage.jsx`, `AdminProductsPage.jsx`, `AdminDashboard.jsx` — updated to surface brand metadata and navigation to the brand manager.
- API client:
  - `adminBrandService.js` encapsulates brand API calls (list/create/update/delete).
  - `adminSupplierService.js` and `adminProductService.js` updated to include brand fields.
- Routing:
  - Admin brands route added in `App.jsx`; pages remain protected by existing RBAC logic.

### Tests
- Current coverage:
  - Unit tests in `AdminServiceImplTest` covering brand create/conflict and supplier-brand replacement logic.
  - Manual checks: backend unit tests run locally (pass); frontend production build succeeded.
- Recommended follow-ups:
  - Integration tests (MockMvc/Testcontainers) for full API contract.
  - E2E UI tests (Cypress/Playwright) for admin flows.

## Acceptance Criteria Checklist
- [x] Supplier creation endpoint + UI implemented and wired with brand assignment.
- [x] Brand entity/model and admin brand management UI implemented (soft-deactivate supported).
- [x] RBAC rules preserved and brand scoping enforced at service layer.
- [x] Tests for brand scoping and supplier deactivation added (unit-level); integration/e2e recommended.

## Test evidence
- Backend unit tests: passed locally for the updated service behaviors.