### PR TITLE
SCRUM-30 : Supplier Dashboard

### DIFF
--- a/backend/src/main/java/com/urbanfresh/controller/SupplierController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/SupplierController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierDashboardResponse;
 import com.urbanfresh.dto.response.SupplierProductResponse;
 import com.urbanfresh.service.SupplierService;
 
@@ -25,6 +26,17 @@ import lombok.RequiredArgsConstructor;
 public class SupplierController {
 
     private final SupplierService supplierService;
+
+    /**
+     * Retrieves aggregated metrics for the supplier dashboard.
+     *
+     * @param authentication authenticated supplier principal
+     * @return dashboard summary including brand names, sales, and restock counts
+     */
+    @GetMapping("/dashboard")
+    public ResponseEntity<SupplierDashboardResponse> getDashboardData(Authentication authentication) {
+        return ResponseEntity.ok(supplierService.getDashboardData(authentication.getName()));
+    }
 
     /**
      * Returns brands assigned to the authenticated supplier.

--- a/backend/src/main/java/com/urbanfresh/dto/response/SupplierDashboardResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/SupplierDashboardResponse.java
@@ -1,0 +1,31 @@
+package com.urbanfresh.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * DTO Layer – Carries supplier dashboard summary data.
+ * Contains brand names, total historical sales, and pending restock metrics.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SupplierDashboardResponse {
+    
+    /** The brand names or primary brand name associated with the supplier */
+    private List<String> brandNames;
+    
+    /** Financial performance summary across all the supplier's products */
+    private BigDecimal totalSales;
+    
+    /** Count of items where stock <= reorder threshold */
+    private int pendingRestocks;
+}

--- a/backend/src/main/java/com/urbanfresh/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/OrderItemRepository.java
@@ -1,9 +1,13 @@
 package com.urbanfresh.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.urbanfresh.model.OrderItem;
+
+import java.math.BigDecimal;
 
 /**
  * Repository Layer – Spring Data JPA repository for OrderItem entities.
@@ -12,4 +16,20 @@ import com.urbanfresh.model.OrderItem;
  */
 @Repository
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    /**
+     * Calculates the total sales for products belonging to the brands assigned to a specific supplier.
+     * Only counts items from orders that are past the pending/unpaid stage.
+     *
+     * @param supplierId the ID of the supplier user
+     * @return the sum of line totals, or null if no sales found
+     */
+    @Query("SELECT SUM(oi.lineTotal) FROM OrderItem oi " +
+           "JOIN oi.product p " +
+           "JOIN p.brand b " +
+           "JOIN SupplierBrand sb ON sb.brand.id = b.id " +
+           "WHERE sb.supplier.id = :supplierId " +
+           "AND oi.order.status IN (com.urbanfresh.model.OrderStatus.CONFIRMED, com.urbanfresh.model.OrderStatus.PROCESSING, " +
+           "com.urbanfresh.model.OrderStatus.READY, com.urbanfresh.model.OrderStatus.OUT_FOR_DELIVERY, com.urbanfresh.model.OrderStatus.DELIVERED)") 
+    BigDecimal calculateTotalSalesForSupplier(@Param("supplierId") Long supplierId);
 }

--- a/backend/src/main/java/com/urbanfresh/repository/ProductRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/ProductRepository.java
@@ -118,4 +118,19 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "AND b.active = true " +
             "ORDER BY p.name ASC")
     List<Product> findProductsForSupplier(@Param("supplierId") Long supplierId);
+
+    /**
+     * Counts the number of products requiring restock across all active brands
+     * assigned to a specific supplier.
+     * 
+     * @param supplierId authenticated supplier user ID
+     * @return count of pending restock products
+     */
+    @Query("SELECT COUNT(DISTINCT p) FROM Product p " +
+           "JOIN p.brand b " +
+           "JOIN SupplierBrand sb ON sb.brand.id = b.id " +
+           "WHERE sb.supplier.id = :supplierId " +
+           "AND b.active = true " +
+           "AND p.stockQuantity <= p.reorderThreshold")
+    int countPendingRestocksForSupplier(@Param("supplierId") Long supplierId);
 }

--- a/backend/src/main/java/com/urbanfresh/service/SupplierService.java
+++ b/backend/src/main/java/com/urbanfresh/service/SupplierService.java
@@ -3,12 +3,21 @@ package com.urbanfresh.service;
 import java.util.List;
 
 import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierDashboardResponse;
 import com.urbanfresh.dto.response.SupplierProductResponse;
 
 /**
  * Service Layer – Supplier-facing operations with brand scoping.
  */
 public interface SupplierService {
+
+    /**
+     * Retrieves aggregated metrics for the supplier dashboard.
+     * 
+     * @param supplierEmail authenticated supplier email
+     * @return dashboard summary including brand names, sales, and restock counts
+     */
+    SupplierDashboardResponse getDashboardData(String supplierEmail);
 
     /**
      * Get all brands assigned to the authenticated supplier.

--- a/backend/src/main/java/com/urbanfresh/service/impl/SupplierServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/SupplierServiceImpl.java
@@ -6,18 +6,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.urbanfresh.dto.response.BrandResponse;
+import com.urbanfresh.dto.response.SupplierDashboardResponse;
 import com.urbanfresh.dto.response.SupplierProductResponse;
 import com.urbanfresh.exception.SupplierInactiveException;
 import com.urbanfresh.model.Product;
 import com.urbanfresh.model.Role;
 import com.urbanfresh.model.SupplierBrand;
 import com.urbanfresh.model.User;
+import com.urbanfresh.repository.OrderItemRepository;
 import com.urbanfresh.repository.ProductRepository;
 import com.urbanfresh.repository.SupplierBrandRepository;
 import com.urbanfresh.repository.UserRepository;
 import com.urbanfresh.service.SupplierService;
 
 import lombok.RequiredArgsConstructor;
+import java.math.BigDecimal;
 
 /**
  * Service Layer – Implements supplier-facing brand-scoped operations.
@@ -29,6 +32,37 @@ public class SupplierServiceImpl implements SupplierService {
     private final UserRepository userRepository;
     private final SupplierBrandRepository supplierBrandRepository;
     private final ProductRepository productRepository;
+    private final OrderItemRepository orderItemRepository;
+
+    /**
+     * Retrieves aggregated metrics for the supplier dashboard.
+     *
+     * @param supplierEmail authenticated supplier email
+     * @return dashboard summary including brand names, sales, and restock counts
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public SupplierDashboardResponse getDashboardData(String supplierEmail) {
+        User supplier = getActiveSupplierByEmail(supplierEmail);
+        
+        List<String> brandNames = supplierBrandRepository.findBySupplierId(supplier.getId())
+                .stream()
+                .map(mapping -> mapping.getBrand().getName())
+                .toList();
+                
+        BigDecimal totalSales = orderItemRepository.calculateTotalSalesForSupplier(supplier.getId());
+        if (totalSales == null) {
+            totalSales = BigDecimal.ZERO;
+        }
+        
+        int pendingRestocks = productRepository.countPendingRestocksForSupplier(supplier.getId());
+        
+        return SupplierDashboardResponse.builder()
+                .brandNames(brandNames)
+                .totalSales(totalSales)
+                .pendingRestocks(pendingRestocks)
+                .build();
+    }
 
     /**
      * Get all brands assigned to the authenticated supplier.

--- a/frontend/src/pages/supplier/SupplierDashboard.jsx
+++ b/frontend/src/pages/supplier/SupplierDashboard.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
-import { getSupplierBrands, getSupplierProducts } from '../../services/supplierService';
+import { getSupplierBrands, getSupplierProducts, getSupplierDashboard } from '../../services/supplierService';
 import { formatPrice } from '../../utils/priceUtils';
 
 /**
@@ -12,20 +12,20 @@ export default function SupplierDashboard() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const [products, setProducts] = useState([]);
-  const [brands, setBrands] = useState([]);
+  const [dashboardData, setDashboardData] = useState(null);
   const [loading, setLoading] = useState(true);
 
   const loadSupplierData = async () => {
     setLoading(true);
     try {
-      const [productData, brandData] = await Promise.all([
+      const [productData, dashboardRes] = await Promise.all([
         getSupplierProducts(),
-        getSupplierBrands(),
+        getSupplierDashboard(),
       ]);
       setProducts(productData);
-      setBrands(brandData);
+      setDashboardData(dashboardRes);
     } catch {
-      toast.error('Failed to load supplier catalog');
+      toast.error('Failed to load supplier dashboard data');
     } finally {
       setLoading(false);
     }
@@ -45,7 +45,7 @@ export default function SupplierDashboard() {
     <div className="min-h-screen bg-blue-50 p-8">
       <div className="max-w-5xl mx-auto bg-white rounded-2xl shadow-md p-8">
         <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold text-green-700">UrbanFresh Supplier</h1>
+          <h1 className="text-2xl font-bold text-green-700">UrbanFresh Supplier Dashboard</h1>
           <button
             onClick={handleLogout}
             className="text-sm text-red-500 hover:text-red-700 font-medium"
@@ -53,53 +53,74 @@ export default function SupplierDashboard() {
             Logout
           </button>
         </div>
-        <p className="text-gray-600">
-          Welcome, <span className="font-semibold">{user?.name}</span> (Supplier)
+        
+        <p className="text-gray-600 mb-6">
+          Welcome, <span className="font-semibold">{user?.name}</span>
         </p>
 
-        <div className="mt-4 p-3 rounded-lg border border-gray-200 bg-gray-50">
-          <p className="text-xs text-gray-500 uppercase tracking-wide mb-1">Assigned Brands</p>
-          {brands.length === 0 ? (
-            <p className="text-sm text-amber-700">No brands assigned yet. Contact an administrator.</p>
-          ) : (
-            <p className="text-sm text-gray-700">{brands.map((brand) => brand.name).join(', ')}</p>
-          )}
-        </div>
+        {loading ? (
+          <p className="text-sm text-gray-500">Loading dashboard...</p>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+              <div className="bg-green-50 p-6 rounded-xl border border-green-100">
+                <h3 className="text-sm font-medium text-green-800 mb-1">Your Brands</h3>
+                <p className="text-xl font-bold text-green-900">
+                  {dashboardData?.brandNames?.length > 0
+                    ? dashboardData.brandNames.join(', ')
+                    : 'No Brands Assigned'}
+                </p>
+              </div>
+              
+              <div className="bg-blue-50 p-6 rounded-xl border border-blue-100">
+                <h3 className="text-sm font-medium text-blue-800 mb-1">Total Sales</h3>
+                <p className="text-xl font-bold text-blue-900">
+                  ${dashboardData?.totalSales?.toFixed(2) || '0.00'}
+                </p>
+              </div>
 
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold text-gray-800 mb-3">Products You Can Manage</h2>
-
-          {loading ? (
-            <p className="text-sm text-gray-500">Loading products...</p>
-          ) : products.length === 0 ? (
-            <p className="text-sm text-gray-500">No products available for your assigned brand(s).</p>
-          ) : (
-            <div className="overflow-x-auto border border-gray-200 rounded-xl">
-              <table className="w-full text-sm">
-                <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
-                  <tr>
-                    <th className={th}>Product</th>
-                    <th className={th}>Brand</th>
-                    <th className={th}>Category</th>
-                    <th className={th}>Price</th>
-                    <th className={th}>Stock</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {products.map((product) => (
-                    <tr key={product.id} className="border-t border-gray-100">
-                      <td className={td}>{product.name}</td>
-                      <td className={td}>{product.brandName || '—'}</td>
-                      <td className={td}>{product.category || '—'}</td>
-                      <td className={td}>{formatPrice(product.price, product.unit)}</td>
-                      <td className={td}>{product.stockQuantity}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              <div className="bg-orange-50 p-6 rounded-xl border border-orange-100">
+                <h3 className="text-sm font-medium text-orange-800 mb-1">Pending Restocks</h3>
+                <p className="text-xl font-bold text-orange-900">
+                  {dashboardData?.pendingRestocks || 0} Items
+                </p>
+              </div>
             </div>
-          )}
-        </div>
+
+            <div className="mt-6">
+              <h2 className="text-lg font-semibold text-gray-800 mb-3">Products You Can Manage</h2>
+              
+              {products.length === 0 ? (
+                <p className="text-sm text-gray-500">No products available for your assigned brand(s).</p>
+              ) : (
+                <div className="overflow-x-auto border border-gray-200 rounded-xl">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                      <tr>
+                        <th className={th}>Product</th>
+                        <th className={th}>Brand</th>
+                        <th className={th}>Category</th>
+                        <th className={th}>Price</th>
+                        <th className={th}>Stock</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {products.map((product) => (
+                        <tr key={product.id} className="border-t border-gray-100">
+                          <td className={td}>{product.name}</td>
+                          <td className={td}>{product.brandName || '—'}</td>
+                          <td className={td}>{product.category || '—'}</td>
+                          <td className={td}>{formatPrice(product.price, product.unit)}</td>
+                          <td className={td}>{product.stockQuantity}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/services/supplierService.js
+++ b/frontend/src/services/supplierService.js
@@ -5,6 +5,14 @@ import api from './api';
  */
 
 /**
+ * Retrieves dashboard summary for the supplier.
+ * 
+ * @returns {Promise<Object>} dashboard summary data
+ */
+export const getSupplierDashboard = () =>
+  api.get('/api/supplier/dashboard').then((res) => res.data);
+
+/**
  * Returns brands assigned to the authenticated supplier.
  *
  * @returns {Promise<Array>} array of BrandResponse


### PR DESCRIPTION
### Summary
Implements the Supplier Dashboard to provide suppliers with visibility into their assigned brands, along with basic performance metrics including total sales and pending restock requests. Includes both backend data aggregation and frontend UI integration protected by supplier RBAC rules.

---

### Changes

#### Backend
| File | Change |
|------|--------|
| `repository/OrderItemRepository.java` | Added JPQL `calculateTotalSalesForSupplier()` to sum `lineTotal` for completed/paid orders linked to a supplier's assigned brands. |
| `repository/ProductRepository.java` | Added JPQL `countPendingRestocksForSupplier()` to count products belonging to the supplier's active brands where stock is at or below the reorder threshold. |
| `dto/response/SupplierDashboardResponse.java` | New DTO - carries aggregated dashboard data: `brandNames`, `totalSales`, and `pendingRestocks`. |
| `service/SupplierService.java` | Added `getDashboardData()` interface method. |
| `service/impl/SupplierServiceImpl.java` | Implemented `getDashboardData()` to aggregate assigned brands, fetch total sales from `OrderItemRepository`, and fetch restock counts from `ProductRepository`. |
| `controller/SupplierController.java` | Added `GET /api/supplier/dashboard` endpoint to serve the aggregated dashboard response. |

#### Frontend
| File | Change |
|------|--------|
| `services/supplierService.js` | Added `getSupplierDashboard()` API call to fetch dashboard metrics. |
| `pages/supplier/SupplierDashboard.jsx` | Updated UI to display a 3-column metrics overview (Assigned Brands, Total Sales, Pending Restocks) above the managed products table. Handles loading states and no-brand fallback. |

---

### API Endpoints Added
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/supplier/dashboard` | SUPPLIER | Retrieves aggregated dashboard metrics (brand list, total sales, pending restocks) scoped to the authenticated supplier |

---

### Acceptance Criteria
- [x] Given a supplier log in, When they open supplier dashboard, Then the brand name associated with their account is displayed
- [x] Given a supplier log in, When they open supplier dashboard, Then a basic sales summary and pending restocks metric are displayed
- [x] Given a non-supplier user opens supplier dashboard, When they access the route, Then they see 403 Unauthorized page (Handled by existing `ProtectedRoute` and backend `@PreAuthorize`)
- [x] Supplier dashboard page implemented
- [x] Backend provides brand + basic summary data
- [x] RBAC enforced and tested