### PR TITLE
SCRUM-35 : Admin Assigns Delivery Personnel to Orders

### DIFF
--- a/backend/src/main/java/com/urbanfresh/controller/AdminController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/AdminController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.urbanfresh.dto.request.AssignDeliveryRequest;
 import com.urbanfresh.dto.request.BrandRequest;
 import com.urbanfresh.dto.request.CreateSupplierRequest;
 import com.urbanfresh.dto.request.OrderStatusUpdateRequest;
@@ -259,6 +260,36 @@ public class AdminController {
             @Valid @RequestBody com.urbanfresh.dto.request.UpdateDeliveryPersonnelStatusRequest request) {
         var response = adminService.updateDeliveryPersonnelStatus(deliveryPersonnelId, request);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Returns all active delivery personnel as a flat list for order-assignment dropdowns.
+     * GET /api/admin/delivery-personnel/active
+     *
+     * @return 200 OK with list of active DeliveryPersonnelResponse
+     */
+    @GetMapping("/delivery-personnel/active")
+    public ResponseEntity<java.util.List<com.urbanfresh.dto.response.DeliveryPersonnelResponse>> getActiveDeliveryPersonnel() {
+        return ResponseEntity.ok(adminService.getActiveDeliveryPersonnel());
+    }
+
+    /**
+     * Assigns an active delivery person to a READY order and moves it to OUT_FOR_DELIVERY.
+     * PUT /api/admin/orders/{orderId}/assign-delivery
+     *
+     * @param orderId        order ID to assign
+     * @param request        payload containing deliveryPersonId
+     * @param authentication authenticated admin principal
+     * @return 200 OK with updated AdminOrderResponse including delivery person info
+     */
+    @PutMapping("/orders/{orderId}/assign-delivery")
+    public ResponseEntity<AdminOrderResponse> assignDelivery(
+            @PathVariable Long orderId,
+            @Valid @RequestBody AssignDeliveryRequest request,
+            Authentication authentication) {
+
+        return ResponseEntity.ok(
+                orderService.assignDeliveryPersonnel(orderId, request.getDeliveryPersonId(), authentication.getName()));
     }
 
     // ── Supplier Management ────────────────────────────────────────────────

--- a/backend/src/main/java/com/urbanfresh/dto/request/AssignDeliveryRequest.java
+++ b/backend/src/main/java/com/urbanfresh/dto/request/AssignDeliveryRequest.java
@@ -1,0 +1,18 @@
+package com.urbanfresh.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO Layer – Request payload for assigning delivery personnel to an order.
+ * Admin submits the ID of the active delivery person to assign.
+ */
+@Getter
+@NoArgsConstructor
+public class AssignDeliveryRequest {
+
+    /** ID of the active delivery personnel user to assign to the order. */
+    @NotNull(message = "Delivery person ID is required.")
+    private Long deliveryPersonId;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/AdminOrderResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/AdminOrderResponse.java
@@ -20,4 +20,10 @@ public class AdminOrderResponse {
     private String paymentStatus;
     private BigDecimal totalAmount;
     private LocalDateTime orderDate;
+
+    /** ID of the delivery person assigned to this order; null if not yet assigned. */
+    private Long deliveryPersonId;
+
+    /** Name of the delivery person assigned to this order; null if not yet assigned. */
+    private String deliveryPersonName;
 }

--- a/backend/src/main/java/com/urbanfresh/model/Order.java
+++ b/backend/src/main/java/com/urbanfresh/model/Order.java
@@ -84,6 +84,14 @@ public class Order {
     @Builder.Default
     private List<OrderItem> items = new ArrayList<>();
 
+    /**
+     * Delivery personnel assigned to fulfil this order.
+     * Null until an admin assigns a delivery person (status transitions to OUT_FOR_DELIVERY).
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_delivery_person_id")
+    private User assignedDeliveryPerson;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/backend/src/main/java/com/urbanfresh/repository/UserRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/UserRepository.java
@@ -30,6 +30,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     /** Find users by role sorted by name for admin listing screens. */
     List<User> findByRoleOrderByNameAsc(Role role);
 
+    /** Find active users by role sorted by name — used for assignment dropdowns. */
+    List<User> findByRoleAndIsActiveTrueOrderByNameAsc(Role role);
+
     /** Find a user by ID and role (used to guard supplier-only operations). */
     Optional<User> findByIdAndRole(Long id, Role role);
 

--- a/backend/src/main/java/com/urbanfresh/service/AdminService.java
+++ b/backend/src/main/java/com/urbanfresh/service/AdminService.java
@@ -49,6 +49,13 @@ public interface AdminService {
     Page<DeliveryPersonnelResponse> getDeliveryPersonnel(Pageable pageable);
 
     /**
+     * Retrieve all active delivery personnel as a flat list for assignment dropdowns.
+     *
+     * @return list of active delivery personnel sorted by name
+     */
+    List<DeliveryPersonnelResponse> getActiveDeliveryPersonnel();
+
+    /**
      * Activate or deactivate a delivery personnel account.
      * When deactivated, the user cannot log in.
      *

--- a/backend/src/main/java/com/urbanfresh/service/OrderService.java
+++ b/backend/src/main/java/com/urbanfresh/service/OrderService.java
@@ -69,4 +69,15 @@ public interface OrderService {
      * @return updated admin-facing order summary
      */
     AdminOrderResponse updateOrderStatus(Long orderId, OrderStatusUpdateRequest request, String adminEmail);
+
+    /**
+     * Assigns an active delivery person to a READY order and transitions
+     * the status to OUT_FOR_DELIVERY.
+     *
+     * @param orderId          ID of the order to assign
+     * @param deliveryPersonId ID of the active DELIVERY role user
+     * @param adminEmail       authenticated admin email used for auditing
+     * @return updated admin-facing order summary with delivery person info
+     */
+    AdminOrderResponse assignDeliveryPersonnel(Long orderId, Long deliveryPersonId, String adminEmail);
 }

--- a/backend/src/main/java/com/urbanfresh/service/impl/AdminServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/AdminServiceImpl.java
@@ -109,6 +109,21 @@ public class AdminServiceImpl implements AdminService {
     }
 
     /**
+     * Retrieve all active delivery personnel as a flat list for assignment dropdowns.
+     * Returns only active accounts so admins cannot assign inactive personnel.
+     *
+     * @return list of active delivery personnel sorted by name
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<DeliveryPersonnelResponse> getActiveDeliveryPersonnel() {
+        return userRepository.findByRoleAndIsActiveTrueOrderByNameAsc(Role.DELIVERY)
+                .stream()
+                .map(this::toDeliveryPersonnelResponse)
+                .toList();
+    }
+
+    /**
      * Activate or deactivate a delivery personnel account by ID.
      *
      * @param deliveryPersonnelId unique identifier

--- a/backend/src/main/java/com/urbanfresh/service/impl/OrderServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/OrderServiceImpl.java
@@ -417,6 +417,7 @@ public class OrderServiceImpl implements OrderService {
          * @return admin-facing order summary
          */
         private AdminOrderResponse toAdminOrderResponse(Order order) {
+                User deliveryPerson = order.getAssignedDeliveryPerson();
                 return AdminOrderResponse.builder()
                                 .orderId(order.getId())
                                 .customerName(order.getCustomer().getName())
@@ -424,6 +425,8 @@ public class OrderServiceImpl implements OrderService {
                                 .paymentStatus(resolvePersistedPaymentStatus(order))
                                 .totalAmount(order.getTotalAmount())
                                 .orderDate(order.getCreatedAt())
+                                .deliveryPersonId(deliveryPerson != null ? deliveryPerson.getId() : null)
+                                .deliveryPersonName(deliveryPerson != null ? deliveryPerson.getName() : null)
                                 .build();
         }
 
@@ -527,5 +530,54 @@ public class OrderServiceImpl implements OrderService {
                 }
 
                 return paymentStatus.name();
+        }
+
+        /**
+         * Assigns an active delivery person to a READY order and transitions the
+         * status to OUT_FOR_DELIVERY. Records an audit history entry.
+         *
+         * @param orderId          ID of the order to assign
+         * @param deliveryPersonId ID of the active DELIVERY role user
+         * @param adminEmail       authenticated admin email for audit trail
+         * @return updated AdminOrderResponse with delivery person info
+         */
+        @Override
+        @Transactional
+        public AdminOrderResponse assignDeliveryPersonnel(Long orderId, Long deliveryPersonId, String adminEmail) {
+                Order order = orderRepository.findById(orderId)
+                                .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+                if (order.getStatus() != OrderStatus.READY) {
+                        throw new InvalidOrderStatusTransitionException(
+                                        "Delivery can only be assigned to orders in READY status. Current status: " + order.getStatus() + "."
+                        );
+                }
+
+                User deliveryPerson = userRepository.findByIdAndRole(deliveryPersonId, com.urbanfresh.model.Role.DELIVERY)
+                                .orElseThrow(() -> new UserNotFoundException(
+                                        "Active delivery personnel not found with ID: " + deliveryPersonId));
+
+                if (!Boolean.TRUE.equals(deliveryPerson.getIsActive())) {
+                        throw new InvalidOrderStatusTransitionException(
+                                        "Cannot assign an inactive delivery person (ID: " + deliveryPersonId + ")."
+                        );
+                }
+
+                User adminUser = userRepository.findByEmail(adminEmail)
+                                .orElseThrow(() -> new UserNotFoundException("Admin not found: " + adminEmail));
+
+                order.setAssignedDeliveryPerson(deliveryPerson);
+                order.setStatus(OrderStatus.OUT_FOR_DELIVERY);
+                Order updated = orderRepository.save(order);
+
+                orderStatusHistoryRepository.save(OrderStatusHistory.builder()
+                                .order(updated)
+                                .previousStatus(OrderStatus.READY)
+                                .newStatus(OrderStatus.OUT_FOR_DELIVERY)
+                                .changedByAdmin(adminUser)
+                                .changeReason("Assigned to delivery personnel: " + deliveryPerson.getName())
+                                .build());
+
+                return toAdminOrderResponse(updated);
         }
 }

--- a/frontend/src/pages/admin/AdminOrdersPage.jsx
+++ b/frontend/src/pages/admin/AdminOrdersPage.jsx
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
-import { getAllOrders, getOrderReview, updateOrderStatus } from '../../services/orderService';
+import {
+  getAllOrders,
+  getOrderReview,
+  updateOrderStatus,
+  assignDeliveryPersonnel,
+  getActiveDeliveryPersonnel,
+} from '../../services/orderService';
 import { formatAmount } from '../../utils/priceUtils';
 import OrderStatusCorrectionModal from '../../components/admin/OrderStatusCorrectionModal';
 import OrderReviewModal from '../../components/admin/OrderReviewModal';
@@ -22,6 +28,8 @@ export default function AdminOrdersPage() {
   const [orderReviewOpen, setOrderReviewOpen] = useState(false);
   const [loadingOrderReview, setLoadingOrderReview] = useState(false);
   const [selectedOrderReview, setSelectedOrderReview] = useState(null);
+  const [deliveryPersonnel, setDeliveryPersonnel] = useState([]);
+  const [selectedDeliveryPerson, setSelectedDeliveryPerson] = useState({});
 
   /**
    * Loads a page of admin orders from the backend.
@@ -44,6 +52,13 @@ export default function AdminOrdersPage() {
   useEffect(() => {
     fetchOrders(currentPage);
   }, [currentPage, fetchOrders]);
+
+  // Load active delivery personnel once for the assignment dropdowns
+  useEffect(() => {
+    getActiveDeliveryPersonnel()
+      .then((list) => setDeliveryPersonnel(list))
+      .catch(() => toast.error('Could not load delivery personnel list.'));
+  }, []);
 
   /**
    * Updates status for a single order row and patches local UI state on success.
@@ -127,6 +142,38 @@ export default function AdminOrdersPage() {
       toast.error('Failed to load order review details. Please try again.');
     } finally {
       setLoadingOrderReview(false);
+    }
+  };
+
+  /**
+   * Assigns the selected delivery person to a READY order.
+   * The backend transitions the order to OUT_FOR_DELIVERY automatically.
+   *
+   * @param {number} orderId target order ID
+   */
+  const handleAssignDelivery = async (orderId) => {
+    const deliveryPersonId = selectedDeliveryPerson[orderId];
+    if (!deliveryPersonId) {
+      toast.error('Please select a delivery person first.');
+      return;
+    }
+    setUpdatingOrderId(orderId);
+    try {
+      const updated = await assignDeliveryPersonnel(orderId, Number(deliveryPersonId));
+      setPageData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          content: prev.content.map((row) => (row.orderId === orderId ? updated : row)),
+        };
+      });
+      setSelectedDeliveryPerson((prev) => { const next = { ...prev }; delete next[orderId]; return next; });
+      toast.success(`Order #${orderId} assigned to ${updated.deliveryPersonName ?? 'delivery person'}.`);
+    } catch (err) {
+      const message = err.response?.data?.message ?? 'Failed to assign delivery person.';
+      toast.error(message);
+    } finally {
+      setUpdatingOrderId(null);
     }
   };
 
@@ -218,29 +265,67 @@ export default function AdminOrdersPage() {
                       </td>
                       <td className={td}>{formatDate(order.orderDate)}</td>
                       <td className={td}>
-                        <div className="flex items-center gap-2">
-                          <select
-                            className="border border-gray-300 rounded-lg px-2 py-1 text-xs disabled:appearance-none disabled:bg-gray-50 disabled:cursor-not-allowed"
-                            value={order.orderStatus}
-                            disabled={
-                              updatingOrderId === order.orderId ||
-                              getAllowedNextStatuses(order.orderStatus).length === 0
-                            }
-                            onChange={(e) => handleStatusChange(order.orderId, e.target.value)}
-                          >
-                            {getStatusOptions(order.orderStatus).map((status) => (
-                              <option key={status} value={status}>
-                                {status}
-                              </option>
-                            ))}
-                          </select>
-                          <button
-                            type="button"
-                            onClick={() => openOrderReview(order.orderId)}
-                            className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
-                          >
-                            Review
-                          </button>
+                        <div className="flex flex-col gap-2">
+                          <div className="flex items-center gap-2">
+                            <select
+                              className="border border-gray-300 rounded-lg px-2 py-1 text-xs disabled:appearance-none disabled:bg-gray-50 disabled:cursor-not-allowed"
+                              value={order.orderStatus}
+                              disabled={
+                                updatingOrderId === order.orderId ||
+                                getAllowedNextStatuses(order.orderStatus).length === 0
+                              }
+                              onChange={(e) => handleStatusChange(order.orderId, e.target.value)}
+                            >
+                              {getStatusOptions(order.orderStatus).map((status) => (
+                                <option key={status} value={status}>
+                                  {status}
+                                </option>
+                              ))}
+                            </select>
+                            <button
+                              type="button"
+                              onClick={() => openOrderReview(order.orderId)}
+                              className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
+                            >
+                              Review
+                            </button>
+                          </div>
+
+                          {order.orderStatus === 'READY' && (
+                            <div className="flex items-center gap-2">
+                              <select
+                                className="border border-blue-300 rounded-lg px-2 py-1 text-xs flex-1 min-w-[130px]"
+                                value={selectedDeliveryPerson[order.orderId] ?? ''}
+                                onChange={(e) =>
+                                  setSelectedDeliveryPerson((prev) => ({
+                                    ...prev,
+                                    [order.orderId]: e.target.value,
+                                  }))
+                                }
+                              >
+                                <option value="">Assign delivery...</option>
+                                {deliveryPersonnel.map((dp) => (
+                                  <option key={dp.id} value={dp.id}>
+                                    {dp.name}
+                                  </option>
+                                ))}
+                              </select>
+                              <button
+                                type="button"
+                                disabled={updatingOrderId === order.orderId || !selectedDeliveryPerson[order.orderId]}
+                                onClick={() => handleAssignDelivery(order.orderId)}
+                                className="rounded-md bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+                              >
+                                Assign
+                              </button>
+                            </div>
+                          )}
+
+                          {order.orderStatus === 'OUT_FOR_DELIVERY' && order.deliveryPersonName && (
+                            <p className="text-xs text-gray-500">
+                              🚚 {order.deliveryPersonName}
+                            </p>
+                          )}
                         </div>
                       </td>
                     </tr>
@@ -313,6 +398,8 @@ function orderBadgeClass(status) {
   if (status === 'READY') return 'text-xs font-semibold px-2.5 py-0.5 rounded-full bg-green-100 text-green-700';
   if (status === 'PROCESSING') return 'text-xs font-semibold px-2.5 py-0.5 rounded-full bg-blue-100 text-blue-700';
   if (status === 'CANCELLED') return 'text-xs font-semibold px-2.5 py-0.5 rounded-full bg-red-100 text-red-700';
+  if (status === 'OUT_FOR_DELIVERY') return 'text-xs font-semibold px-2.5 py-0.5 rounded-full bg-indigo-100 text-indigo-700';
+  if (status === 'DELIVERED') return 'text-xs font-semibold px-2.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700';
   return 'text-xs font-semibold px-2.5 py-0.5 rounded-full bg-yellow-100 text-yellow-700';
 }
 

--- a/frontend/src/services/orderService.js
+++ b/frontend/src/services/orderService.js
@@ -131,3 +131,24 @@ export const updateOrderStatus = (orderId, status, changeReason = null) =>
  */
 export const getOrderReview = (orderId) =>
 	api.get(`/api/admin/orders/${orderId}`).then((res) => res.data);
+
+/**
+ * Assigns an active delivery person to a READY order.
+ * Transitions the order status to OUT_FOR_DELIVERY.
+ * PUT /api/admin/orders/{orderId}/assign-delivery
+ *
+ * @param {number} orderId target order ID (must be READY)
+ * @param {number} deliveryPersonId active delivery personnel user ID
+ * @returns {Promise<Object>} updated AdminOrderResponse with delivery person info
+ */
+export const assignDeliveryPersonnel = (orderId, deliveryPersonId) =>
+	api.put(`/api/admin/orders/${orderId}/assign-delivery`, { deliveryPersonId }).then((res) => res.data);
+
+/**
+ * Fetches all active delivery personnel for the assignment dropdown.
+ * GET /api/admin/delivery-personnel/active
+ *
+ * @returns {Promise<Array>} list of active DeliveryPersonnelResponse objects
+ */
+export const getActiveDeliveryPersonnel = () =>
+	api.get('/api/admin/delivery-personnel/active').then((res) => res.data);


### PR DESCRIPTION
### Summary
Enables admins to assign active delivery personnel to `READY` orders directly from the Order Management page. On assignment, the order status automatically transitions to `OUT_FOR_DELIVERY` and the assigned delivery person is recorded on the order for tracking. Includes full backend enforcement with audit history and a frontend inline assignment control protected by admin RBAC rules.

---

### Changes

#### Backend
| File | Change |
|------|--------|
| `model/Order.java` | Added `assignedDeliveryPerson` — nullable `@ManyToOne` FK to `User` (maps to `assigned_delivery_person_id` column). |
| `repository/UserRepository.java` | Added `findByRoleAndIsActiveTrueOrderByNameAsc()` for fetching active delivery personnel for assignment dropdowns. |
| `dto/request/AssignDeliveryRequest.java` | New DTO — carries `deliveryPersonId` with `@NotNull` validation. |
| `dto/response/AdminOrderResponse.java` | Added `deliveryPersonId` and `deliveryPersonName` fields to surface assignment info on the orders table. |
| `service/OrderService.java` | Added `assignDeliveryPersonnel()` interface method. |
| `service/AdminService.java` | Added `getActiveDeliveryPersonnel()` interface method. |
| `service/impl/OrderServiceImpl.java` | Implemented `assignDeliveryPersonnel()` — validates order is `READY`, verifies delivery person is active, sets status to `OUT_FOR_DELIVERY`, and writes audit history. Updated `toAdminOrderResponse()` to include delivery person fields. |
| `service/impl/AdminServiceImpl.java` | Implemented `getActiveDeliveryPersonnel()` — returns only active `DELIVERY` role users sorted by name. |
| `controller/AdminController.java` | Added `GET /api/admin/delivery-personnel/active` and `PUT /api/admin/orders/{orderId}/assign-delivery` endpoints. |

#### Frontend
| File | Change |
|------|--------|
| `services/orderService.js` | Added `assignDeliveryPersonnel()` and `getActiveDeliveryPersonnel()` API calls. |
| `pages/admin/AdminOrdersPage.jsx` | Loads active delivery personnel on mount; `READY` orders show an inline delivery person selector + Assign button; `OUT_FOR_DELIVERY` orders display the assigned person's name with a 🚚 indicator. Added badge colours for `OUT_FOR_DELIVERY` (indigo) and `DELIVERED` (emerald). |

---

### API Endpoints Added
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/admin/delivery-personnel/active` | ADMIN | Returns all active delivery personnel for assignment dropdowns |
| PUT | `/api/admin/orders/{orderId}/assign-delivery` | ADMIN | Assigns delivery person to a `READY` order; transitions status to `OUT_FOR_DELIVERY` |

---

### Acceptance Criteria
- [x] Admin can assign an active delivery person only to `READY` orders — other statuses are rejected with a descriptive error
- [x] Inactive delivery personnel cannot be assigned
- [x] Order status transitions to `OUT_FOR_DELIVERY` automatically on assignment
- [x] Assignment is recorded in `OrderStatusHistory` for full audit visibility
- [x] Admin Orders page shows delivery person selector only for `READY` rows; confirmed assignments display the assignee's name
- [x] Non-admin users receive 403 (enforced by `SecurityConfig` URL rules + `@PreAuthorize` on `AdminController`)