### PR TITLE
FIX : Premature Loyalty Points

### DIFF
--- a/backend/src/main/java/com/urbanfresh/service/impl/OrderServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/OrderServiceImpl.java
@@ -37,7 +37,6 @@ import com.urbanfresh.repository.OrderRepository;
 import com.urbanfresh.repository.OrderStatusHistoryRepository;
 import com.urbanfresh.repository.ProductRepository;
 import com.urbanfresh.repository.UserRepository;
-import com.urbanfresh.service.LoyaltyService;
 import com.urbanfresh.service.OrderService;
 
 import lombok.RequiredArgsConstructor;
@@ -92,7 +91,6 @@ public class OrderServiceImpl implements OrderService {
         private final OrderStatusHistoryRepository orderStatusHistoryRepository;
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
-    private final LoyaltyService loyaltyService;
 
     /**
      * Places an order for the authenticated customer.
@@ -182,8 +180,8 @@ public class OrderServiceImpl implements OrderService {
 
         Order saved = orderRepository.save(order);
 
-        // Award loyalty points after successful order persistence
-        loyaltyService.awardPoints(customer, total);
+        // Loyalty points are awarded only after payment is confirmed (PENDING → CONFIRMED).
+        // See PaymentServiceImpl.applyPaidState() for the award trigger.
 
         return toOrderResponse(saved);
     }

--- a/backend/src/main/java/com/urbanfresh/service/impl/PaymentServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/PaymentServiceImpl.java
@@ -31,6 +31,7 @@ import com.urbanfresh.model.User;
 import com.urbanfresh.repository.OrderRepository;
 import com.urbanfresh.repository.PaymentRepository;
 import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.LoyaltyService;
 import com.urbanfresh.service.PaymentService;
 
 import lombok.RequiredArgsConstructor;
@@ -76,6 +77,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;
+    private final LoyaltyService loyaltyService;
 
     /**
      * Creates a Stripe PaymentIntent for a customer-owned order.
@@ -379,18 +381,29 @@ public class PaymentServiceImpl implements PaymentService {
      * @param eventType event source that triggered this transition
      */
     private void applyPaidState(Payment payment, String paymentIntentId, String eventType) {
-        payment.setStatus(PaymentStatus.PAID);
-        paymentRepository.save(payment);
-
         Order order = payment.getOrder();
         if (order == null) {
             log.error("Order not found for Payment: {}", payment.getId());
             return;
         }
 
+        // Idempotency guard — both payment_intent.succeeded and charge.updated can call
+        // this method for the same payment. Only process once.
+        if (order.getStatus() == OrderStatus.CONFIRMED) {
+            log.info("Order {} already CONFIRMED — skipping duplicate {} event.", order.getId(), eventType);
+            return;
+        }
+
+        payment.setStatus(PaymentStatus.PAID);
+        paymentRepository.save(payment);
+
         order.setStatus(OrderStatus.CONFIRMED);
         order.setPaymentStatus(PaymentStatus.PAID);
         orderRepository.save(order);
+
+        // Award loyalty points only now — payment is confirmed and the order is CONFIRMED.
+        // Awarding here prevents customers from earning points on failed/cancelled payments.
+        loyaltyService.awardPoints(order.getCustomer(), order.getTotalAmount());
 
         log.info("Order confirmed from {}: orderId={}, paymentIntentId={}",
                 eventType, order.getId(), paymentIntentId);


### PR DESCRIPTION
Closes #32 

### Summary
Fixes a loyalty points integrity bug where points were credited to customers immediately on order placement, before payment was verified. Customers could earn and potentially redeem points even when payment subsequently failed or was cancelled.

---

### Root Cause
`loyaltyService.awardPoints()` was called inside `OrderServiceImpl.placeOrder()` right after the order entity was persisted — at that point the order is still `PENDING` and payment has not been processed. Since Stripe payment is asynchronous via webhook, a failed or cancelled payment left the already-awarded points in place.

Additionally, `applyPaidState()` in `PaymentServiceImpl` is reachable from both `payment_intent.succeeded` and `charge.updated` webhook events for the same payment, which could cause points to be awarded twice.

---

### Fix
- Removed `loyaltyService.awardPoints()` from `OrderServiceImpl.placeOrder()`
- Injected `LoyaltyService` into `PaymentServiceImpl`
- Added `loyaltyService.awardPoints()` inside `applyPaidState()` **guarded by an idempotency check** — points are only awarded when the order transitions from a non-`CONFIRMED` state to `CONFIRMED`, preventing double-award if both `payment_intent.succeeded` and `charge.updated` fire for the same payment

---

### Changes

| File | Change |
|------|--------|
| `service/impl/OrderServiceImpl.java` | Removed `loyaltyService.awardPoints()` call and `LoyaltyService` dependency |
| `service/impl/PaymentServiceImpl.java` | Injected `LoyaltyService`; awards points inside `applyPaidState()` with idempotency guard on order status |

---

### Acceptance Criteria
- [x] Points are **not** awarded when an order is placed (status = `PENDING`)
- [x] Points **are** awarded exactly once when payment succeeds and order transitions to `CONFIRMED`
- [x] Points are **not** awarded if payment fails — order remains `PENDING`
- [x] Points are **not** awarded twice if both `payment_intent.succeeded` and `charge.updated` webhook events fire for the same order
- [x] `BUILD SUCCESS` verified with `mvn clean compile`

---