### PR TITLE
SCRUM-43 : Waste Report Dashboard

### DIFF
--- a/backend/src/main/java/com/urbanfresh/controller/WasteReportController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/WasteReportController.java
@@ -1,0 +1,39 @@
+package com.urbanfresh.controller;
+
+import com.urbanfresh.dto.response.WasteReportResponse;
+import com.urbanfresh.service.WasteReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Waste Report Controller
+ * Layer: Controller (HTTP API)
+ * Exposes the admin waste report endpoint.
+ * URL security is already enforced at the filter chain level via /api/admin/**;
+ * method-level @PreAuthorize provides defence-in-depth.
+ */
+@RestController
+@RequestMapping("/api/admin/waste-report")
+@RequiredArgsConstructor
+public class WasteReportController {
+
+    private final WasteReportService wasteReportService;
+
+    /**
+     * GET /api/admin/waste-report
+     * Returns a full waste report: monthly summaries, top wasted products,
+     * total waste value, total wasted units, and overall waste percentage.
+     * Accessible to ADMIN role only.
+     *
+     * @return WasteReportResponse with all aggregated waste data
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<WasteReportResponse> getWasteReport() {
+        return ResponseEntity.ok(wasteReportService.getWasteReport());
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/WasteMonthSummaryResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/WasteMonthSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.urbanfresh.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response DTO summarising waste data for a single calendar month.
+ * Layer: DTO (Data Transfer Object)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WasteMonthSummaryResponse {
+
+    /** ISO year-month string (e.g. "2026-01") — used for chronological sorting. */
+    private String monthYear;
+
+    /** Human-readable display label (e.g. "Jan 2026") — used on chart axes. */
+    private String monthLabel;
+
+    /** Total monetary waste value for this month (sum of price × wasted quantity). */
+    private BigDecimal wasteValue;
+
+    /** Number of distinct products that expired with remaining stock this month. */
+    private int wastedProductCount;
+
+    /**
+     * Percentage of the grand total waste attributed to this month.
+     * Computed as (monthWasteValue / totalWasteValue) × 100.
+     * Helps identify which months drove the most loss.
+     */
+    private double wastePercentage;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/WasteReportResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/WasteReportResponse.java
@@ -1,0 +1,44 @@
+package com.urbanfresh.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Top-level response DTO for the admin waste report dashboard.
+ * Layer: DTO (Data Transfer Object)
+ * Aggregates expired in-stock products into summary metrics, monthly breakdowns,
+ * and a ranked list of the most costly wasted products.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WasteReportResponse {
+
+    /** Total monetary value of all expired in-stock approved products. */
+    private BigDecimal totalWasteValue;
+
+    /** Total number of wasted units across all expired products. */
+    private int totalWastedUnits;
+
+    /**
+     * Overall waste as a percentage of total approved inventory value.
+     * Computed as (totalWasteValue / totalApprovedInventoryValue) × 100.
+     */
+    private double overallWastePercentage;
+
+    /** Monthly waste totals sorted in ascending chronological order (oldest first). */
+    private List<WasteMonthSummaryResponse> monthlySummaries;
+
+    /** Top wasted products ranked by waste value descending (up to 10 entries). */
+    private List<WastedProductResponse> topWastedProducts;
+
+    /** Timestamp when this report was generated. */
+    private LocalDateTime generatedAt;
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/WastedProductResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/WastedProductResponse.java
@@ -1,0 +1,38 @@
+package com.urbanfresh.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import com.urbanfresh.model.PricingUnit;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response DTO representing a single expired product that contributed to stock waste.
+ * Layer: DTO (Data Transfer Object)
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WastedProductResponse {
+
+    private Long productId;
+    private String productName;
+    private String category;
+    private String brandName;
+    private BigDecimal price;
+    private PricingUnit unit;
+
+    /** Remaining stock at report time — units that could not be sold before expiry. */
+    private int wastedQuantity;
+
+    /** Monetary value of the wasted stock: price × wastedQuantity. */
+    private BigDecimal wastedValue;
+
+    private LocalDate expiryDate;
+
+    /** ISO year-month key (e.g. "2026-01") used for client-side grouping. */
+    private String monthYear;
+}

--- a/backend/src/main/java/com/urbanfresh/repository/ProductRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/ProductRepository.java
@@ -140,4 +140,37 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
      * Find products by approval status with pagination.
      */
     Page<Product> findByApprovalStatus(com.urbanfresh.model.ApprovalStatus status, Pageable pageable);
+
+    /**
+     * Returns all approved products whose expiry date is strictly before the given
+     * cutoff date AND that still have remaining stock.
+     * These are the "wasted" units — stock that was not sold before the product expired.
+     * Results are sorted by expiry date ascending so oldest waste appears first.
+     *
+     * @param cutoff     exclusive upper-bound for expiry (typically today's date — only truly
+     *                   expired products are included, not ones expiring today)
+     * @param minStock   minimum stock threshold; pass 0 to exclude zero-stock rows
+     * @return list of expired in-stock approved products, ordered by expiry date ASC
+     */
+    @Query("SELECT p FROM Product p " +
+           "WHERE p.approvalStatus = 'APPROVED' " +
+           "AND p.expiryDate < :cutoff " +
+           "AND p.stockQuantity > :minStock " +
+           "ORDER BY p.expiryDate ASC")
+    List<Product> findExpiredWithRemainingStock(
+            @Param("cutoff") LocalDate cutoff,
+            @Param("minStock") int minStock
+    );
+
+    /**
+     * Returns the total monetary value of all approved in-stock products.
+     * Used as the denominator when computing the overall waste percentage so
+     * the ratio reflects the share of active inventory that was lost to expiry.
+     *
+     * @return sum of (price × stockQuantity) across all approved in-stock products;
+     *         returns null when no matching rows exist — callers must handle null
+     */
+    @Query("SELECT SUM(p.price * p.stockQuantity) FROM Product p " +
+           "WHERE p.approvalStatus = 'APPROVED' AND p.stockQuantity > 0")
+    java.math.BigDecimal sumApprovedInventoryValue();
 }

--- a/backend/src/main/java/com/urbanfresh/service/WasteReportService.java
+++ b/backend/src/main/java/com/urbanfresh/service/WasteReportService.java
@@ -1,0 +1,20 @@
+package com.urbanfresh.service;
+
+import com.urbanfresh.dto.response.WasteReportResponse;
+
+/**
+ * Waste Report Service Interface
+ * Layer: Service (Business Logic)
+ * Aggregates expired in-stock product data into waste metrics for the admin dashboard.
+ */
+public interface WasteReportService {
+
+    /**
+     * Builds a complete waste report by querying all approved products that
+     * expired with remaining stock, then computing monthly summaries, top
+     * wasted products (ranked by waste value), and an overall waste percentage.
+     *
+     * @return WasteReportResponse containing totals, monthly breakdown, and top wasted products
+     */
+    WasteReportResponse getWasteReport();
+}

--- a/backend/src/main/java/com/urbanfresh/service/impl/WasteReportServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/WasteReportServiceImpl.java
@@ -1,0 +1,204 @@
+package com.urbanfresh.service.impl;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.urbanfresh.dto.response.WasteMonthSummaryResponse;
+import com.urbanfresh.dto.response.WasteReportResponse;
+import com.urbanfresh.dto.response.WastedProductResponse;
+import com.urbanfresh.model.Brand;
+import com.urbanfresh.model.Product;
+import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.service.WasteReportService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Waste Report Service Implementation
+ * Layer: Service (Business Logic)
+ * Fetches all approved products that expired with remaining stock in a single DB query,
+ * then computes monthly summaries and ranks the top wasted products entirely in-memory
+ * to avoid multiple round-trips.
+ */
+@Service
+@RequiredArgsConstructor
+public class WasteReportServiceImpl implements WasteReportService {
+
+    /** Maximum number of products shown in the "top wasted" ranking. */
+    private static final int TOP_WASTED_LIMIT = 10;
+
+    /** Scale used for all BigDecimal division operations. */
+    private static final int SCALE = 2;
+
+    /** Formatter for ISO year-month keys used in grouping (e.g. "2026-01"). */
+    private static final DateTimeFormatter MONTH_KEY_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM");
+
+    /** Formatter for human-readable month labels on chart axes (e.g. "Jan 2026"). */
+    private static final DateTimeFormatter MONTH_LABEL_FMT =
+            DateTimeFormatter.ofPattern("MMM yyyy");
+
+    private final ProductRepository productRepository;
+
+    /**
+     * Builds the full waste report.
+     * Steps:
+     *  1. Load all APPROVED products with expiryDate < today and stockQuantity > 0.
+     *  2. Map each to a WastedProductResponse (wasteValue = price × wastedQuantity).
+     *  3. Compute total waste value and total wasted units.
+     *  4. Group by month and compute per-month summaries with waste percentages.
+     *  5. Rank all wasted products by wastedValue DESC; take top-10.
+     *  6. Compute overall waste % against total approved inventory value.
+     *
+     * @return WasteReportResponse fully populated report
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public WasteReportResponse getWasteReport() {
+        LocalDate today = LocalDate.now();
+
+        // Single query: expired, approved, in-stock products
+        List<Product> expiredProducts =
+                productRepository.findExpiredWithRemainingStock(today, 0);
+
+        List<WastedProductResponse> wastedProducts = expiredProducts.stream()
+                .map(this::toWastedProductResponse)
+                .collect(Collectors.toList());
+
+        BigDecimal totalWasteValue = wastedProducts.stream()
+                .map(WastedProductResponse::getWastedValue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        int totalWastedUnits = wastedProducts.stream()
+                .mapToInt(WastedProductResponse::getWastedQuantity)
+                .sum();
+
+        List<WasteMonthSummaryResponse> monthlySummaries =
+                buildMonthlySummaries(wastedProducts, totalWasteValue);
+
+        List<WastedProductResponse> topWasted = wastedProducts.stream()
+                .sorted(Comparator.comparing(WastedProductResponse::getWastedValue).reversed())
+                .limit(TOP_WASTED_LIMIT)
+                .collect(Collectors.toList());
+
+        double overallWastePercentage = computeOverallWastePercentage(totalWasteValue);
+
+        return WasteReportResponse.builder()
+                .totalWasteValue(totalWasteValue)
+                .totalWastedUnits(totalWastedUnits)
+                .overallWastePercentage(overallWastePercentage)
+                .monthlySummaries(monthlySummaries)
+                .topWastedProducts(topWasted)
+                .generatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────────────
+
+    /**
+     * Maps a Product entity to a WastedProductResponse.
+     * wastedValue = price × stockQuantity (residual units lost to expiry).
+     */
+    private WastedProductResponse toWastedProductResponse(Product product) {
+        Brand brand = product.getBrand();
+        BigDecimal wastedValue = product.getPrice()
+                .multiply(BigDecimal.valueOf(product.getStockQuantity()))
+                .setScale(SCALE, RoundingMode.HALF_UP);
+
+        String monthYear = product.getExpiryDate().format(MONTH_KEY_FMT);
+
+        return new WastedProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getCategory(),
+                brand != null ? brand.getName() : null,
+                product.getPrice(),
+                product.getUnit(),
+                product.getStockQuantity(),
+                wastedValue,
+                product.getExpiryDate(),
+                monthYear
+        );
+    }
+
+    /**
+     * Groups wasted products by their monthYear key and builds a sorted summary list.
+     * Each month's wastePercentage is relative to the grand total waste value.
+     * Months are sorted chronologically (oldest first) for chart display.
+     *
+     * @param wastedProducts  all wasted product rows
+     * @param totalWasteValue grand total to use as percentage denominator
+     * @return list of WasteMonthSummaryResponse sorted by monthYear ASC
+     */
+    private List<WasteMonthSummaryResponse> buildMonthlySummaries(
+            List<WastedProductResponse> wastedProducts,
+            BigDecimal totalWasteValue) {
+
+        // Group by "yyyy-MM" key so months are correctly ordered lexicographically
+        Map<String, List<WastedProductResponse>> byMonth = wastedProducts.stream()
+                .collect(Collectors.groupingBy(WastedProductResponse::getMonthYear));
+
+        return byMonth.entrySet().stream()
+                .map(entry -> {
+                    String key = entry.getKey();
+                    List<WastedProductResponse> monthly = entry.getValue();
+
+                    BigDecimal monthWasteValue = monthly.stream()
+                            .map(WastedProductResponse::getWastedValue)
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+                    double wastePercentage = computePercentage(monthWasteValue, totalWasteValue);
+
+                    // Convert "yyyy-MM" key to human-readable label "MMM yyyy"
+                    String monthLabel = LocalDate.parse(key + "-01").format(MONTH_LABEL_FMT);
+
+                    return new WasteMonthSummaryResponse(
+                            key,
+                            monthLabel,
+                            monthWasteValue,
+                            monthly.size(),
+                            wastePercentage
+                    );
+                })
+                // Lexicographic sort on "yyyy-MM" is identical to chronological order
+                .sorted(Comparator.comparing(WasteMonthSummaryResponse::getMonthYear))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Computes the overall waste percentage:
+     *   (totalWasteValue / totalApprovedInventoryValue) × 100.
+     * Returns 0.0 when inventory value is zero or null (avoids division-by-zero).
+     */
+    private double computeOverallWastePercentage(BigDecimal totalWasteValue) {
+        BigDecimal inventoryValue = productRepository.sumApprovedInventoryValue();
+        if (inventoryValue == null || inventoryValue.compareTo(BigDecimal.ZERO) == 0) {
+            return 0.0;
+        }
+        return computePercentage(totalWasteValue, inventoryValue);
+    }
+
+    /**
+     * Computes (numerator / denominator) × 100, rounded to 2 decimal places.
+     * Returns 0.0 when denominator is zero to prevent ArithmeticException.
+     */
+    private double computePercentage(BigDecimal numerator, BigDecimal denominator) {
+        if (denominator.compareTo(BigDecimal.ZERO) == 0) {
+            return 0.0;
+        }
+        return numerator
+                .multiply(BigDecimal.valueOf(100))
+                .divide(denominator, SCALE, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import AdminSuppliersPage from './pages/admin/AdminSuppliersPage';
 import AdminBrandsPage from './pages/admin/AdminBrandsPage';
 import AdminPurchaseOrdersPage from './pages/admin/AdminPurchaseOrdersPage';
 import AdminExpiryPage from './pages/admin/AdminExpiryPage';
+import AdminWasteReportPage from './pages/admin/AdminWasteReportPage';
 import SupplierDashboard from './pages/supplier/SupplierDashboard';
 import SupplierPurchaseOrdersPage from './pages/supplier/SupplierPurchaseOrdersPage';
 import DeliveryDashboard from './pages/delivery/DeliveryDashboard';
@@ -181,6 +182,14 @@ function App() {
             element={
               <ProtectedRoute allowedRoles={['ADMIN']}>
                 <AdminExpiryPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin/waste-report"
+            element={
+              <ProtectedRoute allowedRoles={['ADMIN']}>
+                <AdminWasteReportPage />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -310,6 +310,17 @@ const AdminDashboard = () => {
                 <p className="text-xs text-gray-400">Near-expiry products by urgency</p>
               </div>
             </Link>
+
+            <Link
+              to="/admin/waste-report"
+              className="flex items-center gap-4 p-4 bg-white border border-red-200 rounded-lg hover:border-red-400 hover:bg-red-50 transition-colors"
+            >
+              <span className="text-3xl">♻️</span>
+              <div>
+                <p className="font-semibold text-gray-800">Waste Report</p>
+                <p className="text-xs text-gray-400">Expired stock waste analysis</p>
+              </div>
+            </Link>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/AdminWasteReportPage.jsx
+++ b/frontend/src/pages/admin/AdminWasteReportPage.jsx
@@ -1,0 +1,298 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { getWasteReport } from '../../services/adminWasteService';
+import { formatAmount, formatPrice } from '../../utils/priceUtils';
+
+/**
+ * Admin Waste Report Page
+ * Layer: Presentation (Admin)
+ * Displays the full expired-stock waste report:
+ *   - KPI cards: total waste value, total wasted units, overall waste %
+ *   - Monthly bar chart: waste value per month (chronological)
+ *   - Top-wasted products table: ranked by waste value descending
+ */
+export default function AdminWasteReportPage() {
+  const [report, setReport]   = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState(null);
+
+  // ── Data fetching ──────────────────────────────────────────────────────────
+
+  const fetchReport = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getWasteReport();
+      setReport(data);
+    } catch {
+      setError('Failed to load waste report. Please try again.');
+      toast.error('Failed to load waste report.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchReport();
+  }, []);
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-8">
+        <div className="max-w-6xl mx-auto">
+          <PageHeader />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="bg-white rounded-lg shadow-sm p-6 animate-pulse">
+                <div className="h-4 bg-gray-200 rounded w-1/2 mb-4" />
+                <div className="h-8 bg-gray-200 rounded w-3/4" />
+              </div>
+            ))}
+          </div>
+          <div className="bg-white rounded-lg shadow-sm p-6 mb-8 animate-pulse">
+            <div className="h-4 bg-gray-200 rounded w-1/4 mb-6" />
+            <div className="h-56 bg-gray-100 rounded" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error state ────────────────────────────────────────────────────────────
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 p-8">
+        <div className="max-w-6xl mx-auto">
+          <PageHeader />
+          <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+            <p className="text-red-800 mb-4">{error}</p>
+            <button
+              onClick={fetchReport}
+              className="bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Success state ──────────────────────────────────────────────────────────
+
+  const {
+    totalWasteValue,
+    totalWastedUnits,
+    overallWastePercentage,
+    monthlySummaries,
+    topWastedProducts,
+    generatedAt,
+  } = report;
+
+  // Recharts expects plain numbers; convert BigDecimal strings → numbers
+  const chartData = (monthlySummaries ?? []).map((m) => ({
+    name: m.monthLabel,
+    wasteValue: Number(m.wasteValue),
+  }));
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-8">
+      <div className="max-w-6xl mx-auto">
+        {/* Header */}
+        <PageHeader />
+        {generatedAt && (
+          <p className="text-xs text-gray-400 -mt-4 mb-8">
+            Generated at: {new Date(generatedAt).toLocaleString()}
+          </p>
+        )}
+
+        {/* ── KPI cards ───────────────────────────────────────────────────── */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          <KpiCard
+            icon="♻️"
+            label="Total Waste Value"
+            value={formatAmount(totalWasteValue)}
+            accent="red"
+          />
+          <KpiCard
+            icon="📦"
+            label="Total Wasted Units"
+            value={totalWastedUnits.toLocaleString()}
+            accent="orange"
+          />
+          <KpiCard
+            icon="📊"
+            label="Overall Waste %"
+            value={`${Number(overallWastePercentage).toFixed(2)}%`}
+            accent="yellow"
+          />
+        </div>
+
+        {/* ── Monthly bar chart ────────────────────────────────────────────── */}
+        <section className="bg-white rounded-lg shadow-sm p-6 mb-8">
+          <h2 className="text-lg font-semibold text-gray-800 mb-6">
+            Waste Value by Month (LKR)
+          </h2>
+          {chartData.length === 0 ? (
+            <p className="text-sm text-gray-400">No monthly data available.</p>
+          ) : (
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={chartData} margin={{ top: 4, right: 16, left: 8, bottom: 4 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                <XAxis
+                  dataKey="name"
+                  tick={{ fontSize: 12, fill: '#6b7280' }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <YAxis
+                  tickFormatter={(v) => `Rs. ${(v / 1000).toFixed(0)}k`}
+                  tick={{ fontSize: 11, fill: '#6b7280' }}
+                  axisLine={false}
+                  tickLine={false}
+                  width={72}
+                />
+                <Tooltip
+                  formatter={(value) => [formatAmount(value), 'Waste Value']}
+                  contentStyle={{
+                    borderRadius: '8px',
+                    border: '1px solid #e5e7eb',
+                    fontSize: '13px',
+                  }}
+                />
+                <Bar dataKey="wasteValue" fill="#ef4444" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </section>
+
+        {/* ── Top wasted products table ────────────────────────────────────── */}
+        <section className="bg-white rounded-lg shadow-sm overflow-hidden mb-8">
+          <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-800">Top Wasted Products</h2>
+            <span className="text-xs text-gray-400">Ranked by waste value (highest first)</span>
+          </div>
+
+          {(!topWastedProducts || topWastedProducts.length === 0) ? (
+            <p className="px-6 py-8 text-sm text-gray-400">No wasted products recorded.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-gray-500 uppercase text-xs">
+                  <tr>
+                    <th className="px-6 py-3 text-left font-medium">#</th>
+                    <th className="px-6 py-3 text-left font-medium">Product</th>
+                    <th className="px-6 py-3 text-left font-medium">Category</th>
+                    <th className="px-6 py-3 text-left font-medium">Brand</th>
+                    <th className="px-6 py-3 text-right font-medium">Unit Price</th>
+                    <th className="px-6 py-3 text-right font-medium">Wasted Qty</th>
+                    <th className="px-6 py-3 text-right font-medium">Waste Value</th>
+                    <th className="px-6 py-3 text-left font-medium">Expiry</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {topWastedProducts.map((product, index) => (
+                    <tr
+                      key={`${product.productId}-${product.monthYear}`}
+                      className="hover:bg-gray-50 transition-colors"
+                    >
+                      <td className="px-6 py-4">
+                        <span
+                          className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold text-white
+                            ${index === 0 ? 'bg-red-500' : index === 1 ? 'bg-orange-400' : index === 2 ? 'bg-yellow-400' : 'bg-gray-300'}`}
+                        >
+                          {index + 1}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 font-medium text-gray-800">{product.productName}</td>
+                      <td className="px-6 py-4 text-gray-500">{product.category}</td>
+                      <td className="px-6 py-4 text-gray-500">{product.brandName ?? '—'}</td>
+                      <td className="px-6 py-4 text-right text-gray-700">
+                        {formatPrice(product.price, product.unit)}
+                      </td>
+                      <td className="px-6 py-4 text-right font-semibold text-red-600">
+                        {product.wastedQuantity.toLocaleString()}
+                      </td>
+                      <td className="px-6 py-4 text-right font-semibold text-red-700">
+                        {formatAmount(product.wastedValue)}
+                      </td>
+                      <td className="px-6 py-4 text-gray-500">{product.expiryDate}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        {/* Back link */}
+        <Link
+          to="/admin"
+          className="text-sm text-green-600 hover:text-green-800 font-medium"
+        >
+          ← Back to Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+/**
+ * Page header: title + back breadcrumb.
+ */
+function PageHeader() {
+  return (
+    <div className="mb-8">
+      <nav className="text-xs text-gray-400 mb-1">
+        <Link to="/admin" className="hover:text-green-600">Dashboard</Link>
+        <span className="mx-1">›</span>
+        <span>Waste Report</span>
+      </nav>
+      <h1 className="text-3xl font-bold text-gray-800">Waste Report Dashboard</h1>
+      <p className="text-sm text-gray-500 mt-1">
+        Approved products that expired with remaining stock (valued waste)
+      </p>
+    </div>
+  );
+}
+
+const ACCENT_CLASSES = {
+  red:    { border: 'border-red-400',    bg: 'bg-red-50',    value: 'text-red-700' },
+  orange: { border: 'border-orange-400', bg: 'bg-orange-50', value: 'text-orange-700' },
+  yellow: { border: 'border-yellow-400', bg: 'bg-yellow-50', value: 'text-yellow-700' },
+};
+
+/**
+ * KPI summary card.
+ * @param {string} icon    - emoji icon
+ * @param {string} label   - metric name
+ * @param {string} value   - pre-formatted display value
+ * @param {string} accent  - one of 'red' | 'orange' | 'yellow'
+ */
+function KpiCard({ icon, label, value, accent }) {
+  const cls = ACCENT_CLASSES[accent] ?? ACCENT_CLASSES.red;
+  return (
+    <div className={`${cls.bg} border-l-4 ${cls.border} bg-white rounded-lg shadow-sm p-6`}>
+      <div className="flex items-center gap-3 mb-3">
+        <span className="text-2xl">{icon}</span>
+        <p className="text-sm font-medium text-gray-600">{label}</p>
+      </div>
+      <p className={`text-2xl font-bold ${cls.value}`}>{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/services/adminWasteService.js
+++ b/frontend/src/services/adminWasteService.js
@@ -1,0 +1,29 @@
+import api from './api';
+
+/**
+ * Admin Waste Report API Service
+ * Layer: Service (API calls)
+ * Handles the HTTP request for the admin waste report.
+ */
+
+/**
+ * Fetch the full waste report for the admin.
+ * Calls GET /api/admin/waste-report.
+ *
+ * @returns {Promise<WasteReportResponse>} report with monthlySummaries,
+ *   topWastedProducts, totalWasteValue, totalWastedUnits, overallWastePercentage
+ * @throws Error if unauthorized (401/403) or request fails
+ */
+export const getWasteReport = async () => {
+  try {
+    const response = await api.get('/api/admin/waste-report');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching waste report:', error);
+    throw error;
+  }
+};
+
+export default {
+  getWasteReport,
+};


### PR DESCRIPTION
### Summary
Implements the Admin Waste Report Dashboard (SCRUM-43) to give admins full visibility into expired-stock waste across the product catalog. Aggregates all approved products that expired with remaining stock, computing total waste value, wasted units, per-month summaries, and a top-wasted-products ranking. Includes backend aggregation pipeline, a REST endpoint, and a dedicated frontend dashboard page protected by admin RBAC rules.

---

### Changes

#### Backend
| File | Change |
|------|--------|
| `dto/response/WastedProductResponse.java` | New DTO — per-product waste details: `productId`, `productName`, `category`, `brandName`, `price`, `unit`, `wastedQuantity`, `wastedValue`, `expiryDate`, `monthYear`. |
| `dto/response/WasteMonthSummaryResponse.java` | New DTO — per-month aggregation: `monthYear` (ISO key), `monthLabel` (display), `wasteValue`, `wastedProductCount`, `wastePercentage` (share of grand total). |
| `dto/response/WasteReportResponse.java` | New DTO — top-level report: `totalWasteValue`, `totalWastedUnits`, `overallWastePercentage`, `monthlySummaries`, `topWastedProducts`, `generatedAt`. |
| `repository/ProductRepository.java` | Added JPQL `findExpiredWithRemainingStock()` to fetch APPROVED products with `expiryDate < today` and `stockQuantity > 0`, ordered by expiry ASC. Added `sumApprovedInventoryValue()` to compute the total approved in-stock inventory value used as the waste percentage denominator. |
| `service/WasteReportService.java` | New interface — declares `getWasteReport()`. |
| `service/impl/WasteReportServiceImpl.java` | Implements `getWasteReport()`: single DB query for expired stock, in-memory grouping into monthly summaries (sorted chronologically), top-10 ranking by waste value, and overall waste % against total approved inventory value. Read-only transactional. |
| `controller/WasteReportController.java` | Added `GET /api/admin/waste-report` endpoint delegating to `WasteReportService`. Method-level `@PreAuthorize("hasRole('ADMIN')")` as defence-in-depth alongside the existing `/api/admin/**` URL security rule. |

#### Frontend
| File | Change |
|------|--------|
| `services/adminWasteService.js` | New service — `getWasteReport()` calls `GET /api/admin/waste-report`. |
| `pages/admin/AdminWasteReportPage.jsx` | New page — KPI cards (Total Waste Value, Total Wasted Units, Overall Waste %), monthly waste bar chart (recharts `BarChart`), and a top-wasted-products table ranked by waste value descending. Includes loading skeleton and error/retry state. Currency formatted via `formatAmount()` / `formatPrice()` utilities. |
| App.jsx | Added `import` and `/admin/waste-report` `ProtectedRoute` (ADMIN only). |
| `pages/admin/AdminDashboard.jsx` | Added "Waste Report" quick-action card in the Quick Actions grid linking to `/admin/waste-report`. |

---

### API Endpoints Added
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/admin/waste-report` | ADMIN | Returns aggregated waste report: monthly summaries, top-10 wasted products, total waste value, total wasted units, and overall waste % against approved inventory value |

---

### Acceptance Criteria
- [x] Given an admin views the waste report, When the page loads, Then monthly waste summary is displayed with waste value per month
- [x] Given an admin views the waste report, When the page loads, Then the top wasted products are ranked by waste value descending
- [x] Given an admin views the waste report, When the page loads, Then total waste value, total wasted units, and overall waste % KPIs are shown
- [x] Given a non-admin user accesses `/admin/waste-report`, When the route is reached, Then they are redirected to the 403 Unauthorized page (handled by existing `ProtectedRoute` and backend `@PreAuthorize`)
- [x] Waste aggregation queries implemented and scoped to APPROVED expired-with-stock products only
- [x] Overall waste percentage computed against total approved inventory value; zero-division guarded
- [x] Admin dashboard includes navigation link to the waste report page
- [x] RBAC enforced at both URL-filter and method level