### PR TITLE
SCRUM-47: Security Audit: Endpoint Access + Validation Pass 

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -101,6 +101,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
@@ -6,10 +6,15 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.urbanfresh.dto.response.ApiErrorResponse;
 
@@ -37,6 +42,77 @@ public class GlobalExceptionHandler {
                 .build();
 
         return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * Handle malformed JSON bodies or unreadable payloads → 400 Bad Request.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleUnreadableMessage(HttpMessageNotReadableException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("Malformed request body")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * Handle query/path parameter type mismatches → 400 Bad Request.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String paramName = ex.getName();
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("Invalid value for parameter '" + paramName + "'.")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * Handle missing required query parameters → 400 Bad Request.
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiErrorResponse> handleMissingRequestParameter(MissingServletRequestParameterException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("Missing required parameter '" + ex.getParameterName() + "'.")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * Handle missing required headers → 400 Bad Request.
+     */
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiErrorResponse> handleMissingRequestHeader(MissingRequestHeaderException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("Missing required header '" + ex.getHeaderName() + "'.")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * Handle unsupported media types → 415 Unsupported Media Type.
+     */
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiErrorResponse> handleUnsupportedMediaType(HttpMediaTypeNotSupportedException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value())
+                .message("Unsupported media type")
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(response);
     }
 
     /**

--- a/backend/src/main/java/com/urbanfresh/security/JwtAuthEntryPoint.java
+++ b/backend/src/main/java/com/urbanfresh/security/JwtAuthEntryPoint.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+import com.urbanfresh.dto.response.ApiErrorResponse;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -34,10 +36,15 @@ public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        // Build JSON manually to avoid hard dependency on ObjectMapper import
+        ApiErrorResponse payload = ApiErrorResponse.builder()
+            .status(HttpStatus.UNAUTHORIZED.value())
+            .message("Session expired or invalid token. Please log in again.")
+            .timestamp(LocalDateTime.now())
+            .build();
+
         String json = String.format(
-                "{\"status\":401,\"message\":\"Session expired or invalid token. Please log in again.\",\"timestamp\":\"%s\"}",
-                LocalDateTime.now()
+            "{\"status\":%d,\"message\":\"%s\",\"timestamp\":\"%s\"}",
+            payload.getStatus(), payload.getMessage(), payload.getTimestamp()
         );
         response.getWriter().write(json);
     }

--- a/backend/src/main/java/com/urbanfresh/security/RoleAccessDeniedHandler.java
+++ b/backend/src/main/java/com/urbanfresh/security/RoleAccessDeniedHandler.java
@@ -9,6 +9,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
+import com.urbanfresh.dto.response.ApiErrorResponse;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -39,10 +41,15 @@ public class RoleAccessDeniedHandler implements AccessDeniedHandler {
         response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        // Build JSON manually — keeps this class dependency-free (no ObjectMapper needed)
+        ApiErrorResponse payload = ApiErrorResponse.builder()
+            .status(HttpStatus.FORBIDDEN.value())
+            .message("Access denied. You do not have permission to perform this action.")
+            .timestamp(LocalDateTime.now())
+            .build();
+
         String json = String.format(
-                "{\"status\":403,\"message\":\"Access denied. You do not have permission to perform this action.\",\"timestamp\":\"%s\"}",
-                LocalDateTime.now()
+            "{\"status\":%d,\"message\":\"%s\",\"timestamp\":\"%s\"}",
+            payload.getStatus(), payload.getMessage(), payload.getTimestamp()
         );
         response.getWriter().write(json);
     }

--- a/backend/src/test/java/com/urbanfresh/security/EndpointSecurityValidationContractTest.java
+++ b/backend/src/test/java/com/urbanfresh/security/EndpointSecurityValidationContractTest.java
@@ -1,0 +1,349 @@
+package com.urbanfresh.security;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.urbanfresh.config.SecurityConfig;
+import com.urbanfresh.controller.AdminDashboardController;
+import com.urbanfresh.controller.CartController;
+import com.urbanfresh.controller.CustomerController;
+import com.urbanfresh.controller.DeliveryController;
+import com.urbanfresh.controller.OrderController;
+import com.urbanfresh.controller.PaymentController;
+import com.urbanfresh.controller.ProductController;
+import com.urbanfresh.controller.ProfileController;
+import com.urbanfresh.controller.SupplierController;
+import com.urbanfresh.dto.AdminDashboardResponse;
+import com.urbanfresh.dto.request.PlaceOrderRequest;
+import com.urbanfresh.dto.response.CartResponse;
+import com.urbanfresh.dto.response.OrderResponse;
+import com.urbanfresh.dto.response.PaymentTrackingStatusResponse;
+import com.urbanfresh.dto.response.ProductPageResponse;
+import com.urbanfresh.dto.response.ProfileResponse;
+import com.urbanfresh.dto.response.SupplierDashboardResponse;
+import com.urbanfresh.exception.GlobalExceptionHandler;
+import com.urbanfresh.service.AdminDashboardService;
+import com.urbanfresh.service.CartService;
+import com.urbanfresh.service.LoyaltyService;
+import com.urbanfresh.service.OrderService;
+import com.urbanfresh.service.PaymentService;
+import com.urbanfresh.service.ProductService;
+import com.urbanfresh.service.ProfileService;
+import com.urbanfresh.service.SupplierService;
+
+/**
+ * Test Layer – Verifies RBAC and 4xx ApiErrorResponse contract for protected and public endpoints.
+ */
+@WebMvcTest(controllers = {
+        AdminDashboardController.class,
+        SupplierController.class,
+        DeliveryController.class,
+        CustomerController.class,
+        CartController.class,
+        OrderController.class,
+        ProfileController.class,
+        PaymentController.class,
+        ProductController.class
+})
+@Import({
+        SecurityConfig.class,
+        JwtAuthEntryPoint.class,
+        RoleAccessDeniedHandler.class,
+        GlobalExceptionHandler.class,
+        JwtAuthFilter.class
+})
+class EndpointSecurityValidationContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminDashboardService adminDashboardService;
+
+    @MockitoBean
+    private SupplierService supplierService;
+
+    @MockitoBean
+    private OrderService orderService;
+
+    @MockitoBean
+    private LoyaltyService loyaltyService;
+
+    @MockitoBean
+    private CartService cartService;
+
+    @MockitoBean
+    private ProfileService profileService;
+
+    @MockitoBean
+    private PaymentService paymentService;
+
+    @MockitoBean
+    private ProductService productService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @BeforeEach
+    void setUp() {
+        when(adminDashboardService.getDashboardMetrics())
+                .thenReturn(new AdminDashboardResponse(0, 0.0, 0, 0, 0, 0, 0.0, null));
+
+        when(supplierService.getDashboardData(anyString()))
+                .thenReturn(SupplierDashboardResponse.builder()
+                        .brandNames(List.of())
+                        .totalSales(BigDecimal.ZERO)
+                        .pendingRestocks(0)
+                        .build());
+
+        when(orderService.getAssignedOrdersForDelivery(anyString(), anyInt(), anyInt()))
+                .thenReturn(Page.empty());
+
+        when(orderService.getMyOrders(anyString()))
+                .thenReturn(List.of());
+
+        when(cartService.getCart(anyString()))
+                .thenReturn(CartResponse.builder()
+                        .items(List.of())
+                        .totalAmount(BigDecimal.ZERO)
+                        .itemCount(0)
+                        .build());
+
+        when(orderService.placeOrder(any(PlaceOrderRequest.class), anyString()))
+                .thenReturn(OrderResponse.builder()
+                        .orderId(1L)
+                        .status("PENDING")
+                        .paymentStatus("PENDING")
+                        .deliveryAddress("No 1, Main Street")
+                        .totalAmount(BigDecimal.valueOf(500.00))
+                        .createdAt(LocalDateTime.now())
+                        .items(List.of())
+                        .build());
+
+        when(profileService.getProfile(anyString()))
+                .thenReturn(ProfileResponse.builder()
+                        .id(1L)
+                        .name("Test User")
+                        .email("user@urbanfresh.com")
+                        .phone("0712345678")
+                        .address("Colombo")
+                        .role("CUSTOMER")
+                        .build());
+
+        when(paymentService.getPaymentTrackingStatus(anyLong(), anyString()))
+                .thenReturn(PaymentTrackingStatusResponse.builder()
+                        .orderId(1L)
+                        .paymentStatus("PENDING")
+                        .chargeUpdatedEventReceived(false)
+                        .terminal(false)
+                        .build());
+
+        when(productService.searchProducts(anyString(), anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(ProductPageResponse.builder()
+                        .products(List.of())
+                        .totalElements(0)
+                        .totalPages(0)
+                        .currentPage(0)
+                        .pageSize(12)
+                        .build());
+
+        when(productService.getNearExpiryProducts(anyInt())).thenReturn(List.of());
+    }
+
+    /**
+     * Confirms ADMIN route blocks unauthenticated users with ApiErrorResponse-shaped 401.
+     */
+    @Test
+    void adminEndpoint_withoutToken_returns401InApiErrorResponseShape() throws Exception {
+        mockMvc.perform(get("/api/admin/dashboard"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    /**
+     * Confirms wrong-role access is denied with ApiErrorResponse-shaped 403.
+     */
+    @Test
+    void adminEndpoint_withCustomerRole_returns403InApiErrorResponseShape() throws Exception {
+        mockMvc.perform(get("/api/admin/dashboard")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    void adminEndpoint_withAdminRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/admin/dashboard")
+                        .with(user("admin@urbanfresh.com").roles("ADMIN")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void supplierEndpoint_withSupplierRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/supplier/dashboard")
+                        .with(user("supplier@urbanfresh.com").roles("SUPPLIER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deliveryEndpoint_withDeliveryRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/delivery/orders")
+                        .with(user("delivery@urbanfresh.com").roles("DELIVERY")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void customerEndpoint_withCustomerRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/customer/orders")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void cartEndpoint_withCustomerRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/cart")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void orderEndpoint_withValidPayload_returns201() throws Exception {
+        String payload = """
+                {
+                  "deliveryAddress": "No 1, Main Street",
+                  "items": [
+                    {"productId": 1, "quantity": 1}
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/orders")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER"))
+                        .contentType(APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void profileEndpoint_withCustomerRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/profile")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void profileEndpoint_withDeliveryRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/profile")
+                        .with(user("delivery@urbanfresh.com").roles("DELIVERY")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void paymentTrackingEndpoint_withCustomerRole_returns200() throws Exception {
+        mockMvc.perform(get("/api/payments/orders/1/status")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER")))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Public endpoint should stay open and handle request safely without authentication.
+     */
+    @Test
+    void publicProductsEndpoint_withoutToken_returns200() throws Exception {
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Public endpoint invalid path variable should return ApiErrorResponse-shaped 400.
+     */
+    @Test
+    void publicProductById_withInvalidPathType_returns400InApiErrorResponseShape() throws Exception {
+        mockMvc.perform(get("/api/products/not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    /**
+     * Missing required webhook header should return ApiErrorResponse-shaped 400.
+     */
+    @Test
+    void paymentWebhook_withoutStripeSignature_returns400InApiErrorResponseShape() throws Exception {
+        mockMvc.perform(post("/api/payments/webhook")
+                        .contentType(APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    /**
+     * Malformed JSON on a protected endpoint should return ApiErrorResponse-shaped 400.
+     */
+    @Test
+    void orderEndpoint_withMalformedJson_returns400InApiErrorResponseShape() throws Exception {
+        mockMvc.perform(post("/api/orders")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER"))
+                        .contentType(APPLICATION_JSON)
+                        .content("{"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    /**
+     * Bean-validation failures should preserve consistent response shape with field-level errors.
+     */
+    @Test
+    void orderEndpoint_withInvalidBody_returns400WithFieldErrors() throws Exception {
+        String payload = """
+                {
+                  "deliveryAddress": "",
+                  "items": []
+                }
+                """;
+
+        mockMvc.perform(post("/api/orders")
+                        .with(user("customer@urbanfresh.com").roles("CUSTOMER"))
+                        .contentType(APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.errors.deliveryAddress").exists())
+                .andExpect(jsonPath("$.errors.items").exists())
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+}

--- a/backend/src/test/java/com/urbanfresh/security/PublicEndpointDataExposureTest.java
+++ b/backend/src/test/java/com/urbanfresh/security/PublicEndpointDataExposureTest.java
@@ -1,0 +1,117 @@
+package com.urbanfresh.security;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.urbanfresh.config.SecurityConfig;
+import com.urbanfresh.controller.ProductController;
+import com.urbanfresh.dto.response.ProductPageResponse;
+import com.urbanfresh.dto.response.ProductResponse;
+import com.urbanfresh.exception.GlobalExceptionHandler;
+import com.urbanfresh.model.PricingUnit;
+import com.urbanfresh.service.ProductService;
+
+/**
+ * Test Layer – Verifies public product endpoints expose only safe fields.
+ */
+@WebMvcTest(controllers = ProductController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthEntryPoint.class,
+        RoleAccessDeniedHandler.class,
+        GlobalExceptionHandler.class,
+        JwtAuthFilter.class
+})
+class PublicEndpointDataExposureTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProductService productService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @BeforeEach
+    void setUp() {
+        ProductResponse product = ProductResponse.builder()
+                .id(1L)
+                .name("Samba Rice 5kg")
+                .description("Premium Samba rice")
+                .price(BigDecimal.valueOf(1400.00))
+                .unit(PricingUnit.PER_ITEM)
+                .category("Grocery")
+                .imageUrl("/assets/images/rice_5kg.jpg")
+                .featured(true)
+                .expiryDate(LocalDate.now().plusDays(20))
+                .inStock(true)
+                .build();
+
+        when(productService.searchProducts(nullable(String.class), nullable(String.class), nullable(String.class), anyInt(), anyInt()))
+                .thenReturn(ProductPageResponse.builder()
+                        .products(List.of(product))
+                        .totalElements(1)
+                        .totalPages(1)
+                        .currentPage(0)
+                        .pageSize(12)
+                        .build());
+
+        when(productService.getProductById(anyLong())).thenReturn(product);
+    }
+
+    /**
+     * Catalogue response should include public product fields without internal/sensitive fields.
+     */
+    @Test
+    void getProducts_doesNotExposeInternalOrSensitiveFields() throws Exception {
+        mockMvc.perform(get("/api/products"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.products[0].id").value(1))
+                .andExpect(jsonPath("$.products[0].name").value("Samba Rice 5kg"))
+                .andExpect(jsonPath("$.products[0].price").value(1400.0))
+                .andExpect(jsonPath("$.products[0].inStock").value(true))
+                .andExpect(jsonPath("$.products[0].stockQuantity").doesNotExist())
+                .andExpect(jsonPath("$.products[0].reorderThreshold").doesNotExist())
+                .andExpect(jsonPath("$.products[0].password").doesNotExist())
+                .andExpect(jsonPath("$.products[0].token").doesNotExist())
+                .andExpect(jsonPath("$.products[0].supplierEmail").doesNotExist());
+    }
+
+    /**
+     * Product detail should include only safe fields for public consumption.
+     */
+    @Test
+    void getProductById_doesNotExposeInternalOrSensitiveFields() throws Exception {
+        mockMvc.perform(get("/api/products/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Samba Rice 5kg"))
+                .andExpect(jsonPath("$.price").value(1400.0))
+                .andExpect(jsonPath("$.inStock").value(true))
+                .andExpect(jsonPath("$.stockQuantity").doesNotExist())
+                .andExpect(jsonPath("$.reorderThreshold").doesNotExist())
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.token").doesNotExist())
+                .andExpect(jsonPath("$.internalCost").doesNotExist());
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4223,9 +4223,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,37 +1,40 @@
+import React, { Suspense, lazy } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 import { AuthProvider } from './context/AuthContext';
 import { CartProvider } from './context/CartContext';
-import CartPage from './pages/customer/CartPage';
-import CheckoutPage from './pages/customer/CheckoutPage';
 import ProtectedRoute from './components/ProtectedRoute';
-import LandingPage from './pages/landing/LandingPage';
-import RegisterPage from './pages/auth/RegisterPage';
-import LoginPage from './pages/auth/LoginPage';
-import ProductListingPage from './pages/products/ProductListingPage';
-import ProductDetailPage from './pages/products/ProductDetailPage';
-import CustomerDashboard from './pages/customer/CustomerDashboard';
-import ProfilePage from './pages/customer/ProfilePage';
-import OrderSuccessPage from './pages/customer/OrderSuccessPage';
-import AdminDashboard from './pages/admin/AdminDashboard';
-import AdminProductsPage from './pages/admin/AdminProductsPage';
-import AdminInventoryPage from './pages/admin/AdminInventoryPage';
-import AdminOrdersPage from './pages/admin/AdminOrdersPage';
-import AdminProfilePage from './pages/admin/AdminProfilePage';
-import DeliveryPersonnelPage from './pages/admin/DeliveryPersonnelPage';
-import AdminSuppliersPage from './pages/admin/AdminSuppliersPage';
-import AdminBrandsPage from './pages/admin/AdminBrandsPage';
-import AdminPurchaseOrdersPage from './pages/admin/AdminPurchaseOrdersPage';
-import AdminExpiryPage from './pages/admin/AdminExpiryPage';
-import AdminWasteReportPage from './pages/admin/AdminWasteReportPage';
-import SupplierDashboard from './pages/supplier/SupplierDashboard';
-import SupplierPurchaseOrdersPage from './pages/supplier/SupplierPurchaseOrdersPage';
-import DeliveryDashboard from './pages/delivery/DeliveryDashboard';
-import DeliveryCurrentOrdersPage from './pages/delivery/DeliveryCurrentOrdersPage';
-import DeliveryOrderHistoryPage from './pages/delivery/DeliveryOrderHistoryPage';
-import DeliveryOrderDetailsPage from './pages/delivery/DeliveryOrderDetailsPage';
-import DeliveryProfilePage from './pages/delivery/DeliveryProfilePage';
-import UnauthorizedPage from './pages/error/UnauthorizedPage';
+
+// Lazy-loaded pages to enable code-splitting and smaller initial bundle
+const LandingPage = lazy(() => import('./pages/landing/LandingPage'));
+const ProductListingPage = lazy(() => import('./pages/products/ProductListingPage'));
+const ProductDetailPage = lazy(() => import('./pages/products/ProductDetailPage'));
+const RegisterPage = lazy(() => import('./pages/auth/RegisterPage'));
+const LoginPage = lazy(() => import('./pages/auth/LoginPage'));
+const CartPage = lazy(() => import('./pages/customer/CartPage'));
+const CheckoutPage = lazy(() => import('./pages/customer/CheckoutPage'));
+const CustomerDashboard = lazy(() => import('./pages/customer/CustomerDashboard'));
+const ProfilePage = lazy(() => import('./pages/customer/ProfilePage'));
+const OrderSuccessPage = lazy(() => import('./pages/customer/OrderSuccessPage'));
+const AdminDashboard = lazy(() => import('./pages/admin/AdminDashboard'));
+const AdminProductsPage = lazy(() => import('./pages/admin/AdminProductsPage'));
+const AdminInventoryPage = lazy(() => import('./pages/admin/AdminInventoryPage'));
+const AdminOrdersPage = lazy(() => import('./pages/admin/AdminOrdersPage'));
+const AdminProfilePage = lazy(() => import('./pages/admin/AdminProfilePage'));
+const DeliveryPersonnelPage = lazy(() => import('./pages/admin/DeliveryPersonnelPage'));
+const AdminSuppliersPage = lazy(() => import('./pages/admin/AdminSuppliersPage'));
+const AdminBrandsPage = lazy(() => import('./pages/admin/AdminBrandsPage'));
+const AdminPurchaseOrdersPage = lazy(() => import('./pages/admin/AdminPurchaseOrdersPage'));
+const AdminExpiryPage = lazy(() => import('./pages/admin/AdminExpiryPage'));
+const AdminWasteReportPage = lazy(() => import('./pages/admin/AdminWasteReportPage'));
+const SupplierDashboard = lazy(() => import('./pages/supplier/SupplierDashboard'));
+const SupplierPurchaseOrdersPage = lazy(() => import('./pages/supplier/SupplierPurchaseOrdersPage'));
+const DeliveryDashboard = lazy(() => import('./pages/delivery/DeliveryDashboard'));
+const DeliveryCurrentOrdersPage = lazy(() => import('./pages/delivery/DeliveryCurrentOrdersPage'));
+const DeliveryOrderHistoryPage = lazy(() => import('./pages/delivery/DeliveryOrderHistoryPage'));
+const DeliveryOrderDetailsPage = lazy(() => import('./pages/delivery/DeliveryOrderDetailsPage'));
+const DeliveryProfilePage = lazy(() => import('./pages/delivery/DeliveryProfilePage'));
+const UnauthorizedPage = lazy(() => import('./pages/error/UnauthorizedPage'));
 
 /**
  * App – Root component.
@@ -44,6 +47,7 @@ function App() {
     <AuthProvider>
       <CartProvider>
       <BrowserRouter>
+        <Suspense fallback={<div className="app-loading">Loading...</div>}>
         {/* Global toast notifications */}
         <Toaster position="top-right" toastOptions={{ duration: 4000 }} />
         <Routes>
@@ -253,6 +257,7 @@ function App() {
           {/* Default redirect */}
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
+        </Suspense>
       </BrowserRouter>
       </CartProvider>
     </AuthProvider>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,54 @@ import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  build: {
+    // Split large vendors into named chunks to reduce single chunk size
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          // Map node_modules package to a named vendor chunk by package name.
+          // This avoids circular chunking and creates predictable vendor bundles.
+          if (!id.includes('node_modules')) return null;
+
+          const parts = id.split('node_modules/')[1].split('/');
+          const pkg = parts[0].startsWith('@') ? parts.slice(0,2).join('/') : parts[0];
+
+          // Only split out known large/important vendor packages. For all other
+          // packages, return null and let Rollup optimize them into existing
+          // vendor bundles. This avoids creating many small or empty chunks.
+          const whitelist = new Set([
+            'recharts',
+            'react',
+            'react-dom',
+            'react-icons',
+            '@stripe/react-stripe-js',
+            '@stripe/stripe-js',
+            'axios',
+            'react-router-dom'
+          ]);
+
+          if (!whitelist.has(pkg)) return null;
+
+          switch (pkg) {
+            case 'recharts':
+              return 'vendor-recharts';
+            case 'react':
+            case 'react-dom':
+              return 'vendor-react';
+            case 'react-icons':
+              return 'vendor-icons';
+            case '@stripe/react-stripe-js':
+            case '@stripe/stripe-js':
+              return 'vendor-stripe';
+            case 'axios':
+              return 'vendor-axios';
+            case 'react-router-dom':
+              return 'vendor-react-router-dom';
+            default:
+              return null;
+          }
+        }
+      }
+    }
+  },
 })


### PR DESCRIPTION
## Summary
Implement a consistent 4xx API error contract and align security handlers, include public endpoints in the validation/security audit, and fix frontend chunking to reduce oversized bundles. This standardizes client-facing error responses, hardens demoable security behavior, and improves frontend production bundle size and caching.

## Why
- Consistent error payloads reduce client parsing complexity and front-end branching logic.
- Ensures security-related responses (401/403) follow the same `ApiErrorResponse` contract.
- Public endpoints are validated for exposure and validation behavior.
- Frontend chunking improvements reduce initial load and avoid oversized/empty chunks.

## What changed (high-level)
- Backend:
  - Centralized and extended 4xx handling to cover validation, malformed JSON, type mismatches, missing headers/params, and unsupported media types.
  - Security handlers (401/403) now return `ApiErrorResponse` shaped JSON.
  - DB seed/schema updated to include `approval_status` for `products` so repository queries succeed.
  - Defensive change: disable Hibernate auto-update to avoid runtime schema drift during startup (`spring.jpa.hibernate.ddl-auto=none`).
  - Added focused controller-level tests for RBAC and public endpoint exposure.
- Frontend:
  - Route pages converted to dynamic imports via `React.lazy` and wrapped in `Suspense`.
  - `vite.config.js` updated with `manualChunks` vendor-splitting (whitelist-based) to isolate heavy libs and avoid empty/circular chunks.

## Key Behavioural Changes (Before → After)
- Before: Multiple code paths returned different JSON for 4xx errors; security handlers returned custom shapes; some public endpoints lacked exposure checks; frontend build produced oversized and/or empty chunks.
- After: All 4xx responses (validation + security) return `ApiErrorResponse` with `status`, `message`, `timestamp`, and `errors` when applicable; public endpoints covered by tests; frontend builds produce predictable vendor chunks and smaller main chunks.

## Implementation Details

### Backend
- Controllers:
  - No functional endpoint changes; central `GlobalExceptionHandler` formats client-facing 4xx responses.
- Security:
  - `JwtAuthEntryPoint` / `RoleAccessDeniedHandler` produce API-shaped 401/403 bodies.
- Config:
  - `spring.jpa.hibernate.ddl-auto` set to `none` in `application.properties`.
  - `data.sql` updated to include `approval_status` column in `products` table (default `APPROVED`) to match `Product.approvalStatus` usage in code.
- Error handling:
  - `GlobalExceptionHandler` now handles:
    - `MethodArgumentNotValidException` (field errors)
    - `HttpMessageNotReadableException` (malformed JSON)
    - `MethodArgumentTypeMismatchException` (path/query type mismatch)
    - `MissingServletRequestParameterException` / `MissingRequestHeaderException`
    - `HttpMediaTypeNotSupportedException`
    - Domain exceptions (404/409/401/403) and a catch-all 500.

### Frontend
- `App.jsx`:
  - Converted page imports to `React.lazy(...)` and wrapped routes with `Suspense` fallback.
- `vite.config.js`:
  - Added `build.rollupOptions.output.manualChunks` mapping to create stable vendor chunks (e.g., react, react-router-dom, recharts, axios) and avoid empty/circular chunks.
- No runtime API changes; only build/time-splitting improvements.

## Tests
- New tests added:
  - `EndpointSecurityValidationContractTest` — verifies RBAC and 4xx contract across protected and public endpoints.
  - `PublicEndpointDataExposureTest` — asserts public product endpoints do not expose internal fields.
- Local verification:
  - Targeted backend tests executed: tests pass (targeted run: 18 tests, 0 failures).
  - Manual verification: `GET /api/products` returned 200 and expected product list after schema fix.
- Recommended follow-ups:
  - Add CI step to run these Web MVC slice tests.
  - Optionally run a Newman job for full collection verification (excluded from this PR per scope).

## Acceptance Criteria
- [x] All 4xx responses use `ApiErrorResponse` shape (status/message/timestamp/errors when applicable).
- [x] Security 401/403 responses follow the same API error contract.
- [x] Public endpoints are included in the validation/security audit and have tests for sensitive-field exposure.
- [x] Frontend production build no longer produces oversized main chunk and avoids empty/circular chunks.