### PR TITLE
SCRUM-45 : In-App Notifications for Order Status Updates

### DIFF
--- a/backend/src/main/java/com/urbanfresh/config/SecurityConfig.java
+++ b/backend/src/main/java/com/urbanfresh/config/SecurityConfig.java
@@ -92,6 +92,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/orders/**").authenticated()
                         // Customer dashboard endpoints (order history + loyalty) — CUSTOMER only via @PreAuthorize
                         .requestMatchers("/api/customer/**").authenticated()
+                        // In-app notification endpoints — CUSTOMER only via @PreAuthorize
+                        .requestMatchers("/api/notifications/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/backend/src/main/java/com/urbanfresh/controller/NotificationController.java
+++ b/backend/src/main/java/com/urbanfresh/controller/NotificationController.java
@@ -1,0 +1,92 @@
+package com.urbanfresh.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.urbanfresh.dto.response.NotificationResponse;
+import com.urbanfresh.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Controller Layer – Exposes notification endpoints for authenticated customers.
+ * Route prefix: /api/notifications
+ * Access: ROLE_CUSTOMER only (enforced via @PreAuthorize on each method).
+ */
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /**
+     * Returns all notifications for the authenticated customer, newest first.
+     * GET /api/notifications
+     *
+     * @param authentication Spring Security principal — used to extract caller's email
+     * @return 200 OK with list of NotificationResponse (empty list when none exist)
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<List<NotificationResponse>> getMyNotifications(Authentication authentication) {
+        return ResponseEntity.ok(
+                notificationService.getMyNotifications(authentication.getName()));
+    }
+
+    /**
+     * Returns the count of unread notifications for the authenticated customer.
+     * Used by the notification bell badge in the frontend.
+     * GET /api/notifications/unread-count
+     *
+     * @param authentication Spring Security principal
+     * @return 200 OK with plain long count
+     */
+    @GetMapping("/unread-count")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<Long> getUnreadCount(Authentication authentication) {
+        return ResponseEntity.ok(
+                notificationService.countUnread(authentication.getName()));
+    }
+
+    /**
+     * Marks a single notification as read.
+     * Enforces ownership — returns 404 when the notification does not belong to the caller.
+     * PATCH /api/notifications/{id}/read
+     *
+     * @param id             path variable — notification ID to mark as read
+     * @param authentication Spring Security principal
+     * @return 200 OK with the updated NotificationResponse
+     */
+    @PatchMapping("/{id}/read")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<NotificationResponse> markAsRead(
+            @PathVariable Long id,
+            Authentication authentication) {
+        return ResponseEntity.ok(
+                notificationService.markAsRead(id, authentication.getName()));
+    }
+
+    /**
+     * Marks all of the authenticated customer's notifications as read.
+     * POST /api/notifications/read-all
+     *
+     * @param authentication Spring Security principal
+     * @return 204 No Content on success
+     */
+    @PostMapping("/read-all")
+    @PreAuthorize("hasRole('CUSTOMER')")
+    public ResponseEntity<Void> markAllAsRead(Authentication authentication) {
+        notificationService.markAllAsRead(authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/NotificationResponse.java
@@ -1,0 +1,25 @@
+package com.urbanfresh.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO Layer – Response payload for a single customer notification.
+ * Returned by GET /api/notifications and PATCH /api/notifications/{id}/read.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+
+    private Long id;
+    private Long orderId;
+    private String message;
+    private boolean read;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/urbanfresh/exception/GlobalExceptionHandler.java
@@ -357,6 +357,19 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handle notification not found or not owned by the requesting customer → 404 Not Found.
+     */
+    @ExceptionHandler(NotificationNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotificationNotFound(NotificationNotFoundException ex) {
+        ApiErrorResponse response = ApiErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    /**
      * Catch-all for unexpected errors → 500 Internal Server Error.
      * Logs the actual exception but returns a generic message to the client.
      */

--- a/backend/src/main/java/com/urbanfresh/exception/NotificationNotFoundException.java
+++ b/backend/src/main/java/com/urbanfresh/exception/NotificationNotFoundException.java
@@ -1,0 +1,17 @@
+package com.urbanfresh.exception;
+
+/**
+ * Exception Layer – Thrown when a notification cannot be found by ID,
+ * or when a customer attempts to access a notification they do not own.
+ */
+public class NotificationNotFoundException extends RuntimeException {
+
+    /**
+     * Creates an exception for a missing or inaccessible notification.
+     *
+     * @param notificationId the requested notification ID
+     */
+    public NotificationNotFoundException(Long notificationId) {
+        super("Notification not found with id: " + notificationId);
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/model/Notification.java
+++ b/backend/src/main/java/com/urbanfresh/model/Notification.java
@@ -1,0 +1,68 @@
+package com.urbanfresh.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Domain Layer – JPA entity representing an in-app notification sent to a customer
+ * when their order status changes. Maps to the "notifications" table in MySQL.
+ */
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** The customer who receives this notification. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private User customer;
+
+    /**
+     * The ID of the related order.
+     * Stored as a plain Long (not a FK join) to keep reads lightweight
+     * and avoid cascading issues if an order is ever hard-deleted.
+     */
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    /** Human-readable notification text describing the status change. */
+    @Column(nullable = false, length = 255)
+    private String message;
+
+    /** Whether the customer has acknowledged this notification. */
+    @Builder.Default
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** Captures the creation timestamp automatically before first insert. */
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/urbanfresh/repository/NotificationRepository.java
@@ -1,0 +1,49 @@
+package com.urbanfresh.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.urbanfresh.model.Notification;
+
+/**
+ * Repository Layer – Data access for Notification entities.
+ * All queries are scoped to a specific customer to enforce data isolation.
+ */
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    /**
+     * Returns all notifications for a customer, newest first.
+     *
+     * @param customerId the customer's user ID
+     * @return ordered list of notifications
+     */
+    List<Notification> findByCustomerIdOrderByCreatedAtDesc(Long customerId);
+
+    /**
+     * Returns a notification only if it belongs to the given customer.
+     * Used to enforce ownership before marking as read.
+     *
+     * @param id         notification ID
+     * @param customerId the customer's user ID
+     * @return the notification if owned by this customer
+     */
+    Optional<Notification> findByIdAndCustomerId(Long id, Long customerId);
+
+    /** Count unread notifications for a customer. */
+    long countByCustomerIdAndIsReadFalse(Long customerId);
+
+    /**
+     * Bulk-marks all of a customer's unread notifications as read.
+     * Single UPDATE statement — avoids loading all entities into memory.
+     *
+     * @param customerId the customer's user ID
+     */
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.customer.id = :customerId AND n.isRead = false")
+    void markAllReadByCustomerId(@Param("customerId") Long customerId);
+}

--- a/backend/src/main/java/com/urbanfresh/service/NotificationService.java
+++ b/backend/src/main/java/com/urbanfresh/service/NotificationService.java
@@ -1,0 +1,57 @@
+package com.urbanfresh.service;
+
+import java.util.List;
+
+import com.urbanfresh.dto.response.NotificationResponse;
+import com.urbanfresh.model.Order;
+import com.urbanfresh.model.OrderStatus;
+
+/**
+ * Service Layer – Contract for in-app notification operations.
+ * Notifications are created on order status changes and read by customers
+ * via the dashboard.
+ */
+public interface NotificationService {
+
+    /**
+     * Creates and persists a notification for the order's customer
+     * reflecting the given new status.
+     *
+     * @param order     the order whose status changed
+     * @param newStatus the status the order transitioned to
+     */
+    void createOrderStatusNotification(Order order, OrderStatus newStatus);
+
+    /**
+     * Returns all notifications for the authenticated customer, newest first.
+     *
+     * @param customerEmail email from the JWT principal
+     * @return list of notification DTOs; empty when none exist
+     */
+    List<NotificationResponse> getMyNotifications(String customerEmail);
+
+    /**
+     * Returns the count of unread notifications for the authenticated customer.
+     *
+     * @param customerEmail email from the JWT principal
+     * @return unread notification count
+     */
+    long countUnread(String customerEmail);
+
+    /**
+     * Marks a single notification as read.
+     * Enforces ownership — a customer can only mark their own notifications.
+     *
+     * @param notificationId ID of the notification to mark as read
+     * @param customerEmail  email from the JWT principal
+     * @return the updated notification DTO
+     */
+    NotificationResponse markAsRead(Long notificationId, String customerEmail);
+
+    /**
+     * Marks all of the authenticated customer's notifications as read.
+     *
+     * @param customerEmail email from the JWT principal
+     */
+    void markAllAsRead(String customerEmail);
+}

--- a/backend/src/main/java/com/urbanfresh/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,171 @@
+package com.urbanfresh.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.urbanfresh.dto.response.NotificationResponse;
+import com.urbanfresh.exception.NotificationNotFoundException;
+import com.urbanfresh.exception.UserNotFoundException;
+import com.urbanfresh.model.Notification;
+import com.urbanfresh.model.Order;
+import com.urbanfresh.model.OrderStatus;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.NotificationRepository;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Service Layer – Implements in-app notification creation and retrieval.
+ * Notifications are created whenever an order status changes and are surfaced
+ * to the customer via the dashboard. Ownership is enforced on every read operation.
+ */
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * Builds a customer-friendly message for the given status and persists a
+     * Notification linked to the order's customer.
+     * Called from OrderServiceImpl and PaymentServiceImpl after every status save.
+     *
+     * @param order     the updated order (must have customer eagerly available)
+     * @param newStatus the status the order just transitioned to
+     */
+    @Override
+    @Transactional
+    public void createOrderStatusNotification(Order order, OrderStatus newStatus) {
+        String message = buildMessage(order.getId(), newStatus);
+
+        notificationRepository.save(Notification.builder()
+                .customer(order.getCustomer())
+                .orderId(order.getId())
+                .message(message)
+                .build());
+    }
+
+    /**
+     * Returns all notifications for the authenticated customer, newest first.
+     *
+     * @param customerEmail email from the JWT principal
+     * @return list of notification response DTOs; empty when none exist
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getMyNotifications(String customerEmail) {
+        User customer = resolveCustomer(customerEmail);
+        return notificationRepository
+                .findByCustomerIdOrderByCreatedAtDesc(customer.getId())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    /**
+     * Returns the count of unread notifications for the authenticated customer.
+     *
+     * @param customerEmail email from the JWT principal
+     * @return number of unread notifications
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public long countUnread(String customerEmail) {
+        User customer = resolveCustomer(customerEmail);
+        return notificationRepository.countByCustomerIdAndIsReadFalse(customer.getId());
+    }
+
+    /**
+     * Marks a single notification as read.
+     * Uses a combined id+customerId lookup to enforce ownership without a
+     * separate ownership check query.
+     *
+     * @param notificationId ID of the notification to mark read
+     * @param customerEmail  email from the JWT principal
+     * @return updated notification DTO
+     * @throws NotificationNotFoundException when the notification does not exist
+     *         or belongs to a different customer
+     */
+    @Override
+    @Transactional
+    public NotificationResponse markAsRead(Long notificationId, String customerEmail) {
+        User customer = resolveCustomer(customerEmail);
+
+        Notification notification = notificationRepository
+                .findByIdAndCustomerId(notificationId, customer.getId())
+                .orElseThrow(() -> new NotificationNotFoundException(notificationId));
+
+        // No-op when already read — avoids an unnecessary dirty write
+        if (!notification.isRead()) {
+            notification.setRead(true);
+            notificationRepository.save(notification);
+        }
+
+        return toResponse(notification);
+    }
+
+    /**
+     * Marks all of the authenticated customer's unread notifications as read.
+     * Uses a single bulk UPDATE to avoid loading entities into memory.
+     *
+     * @param customerEmail email from the JWT principal
+     */
+    @Override
+    @Transactional
+    public void markAllAsRead(String customerEmail) {
+        User customer = resolveCustomer(customerEmail);
+        notificationRepository.markAllReadByCustomerId(customer.getId());
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /**
+     * Resolves the User entity for the given email.
+     * Centralised to keep all five public methods DRY.
+     */
+    private User resolveCustomer(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("Customer not found: " + email));
+    }
+
+    /**
+     * Maps a Notification entity to its response DTO.
+     */
+    private NotificationResponse toResponse(Notification n) {
+        return NotificationResponse.builder()
+                .id(n.getId())
+                .orderId(n.getOrderId())
+                .message(n.getMessage())
+                .read(n.isRead())
+                .createdAt(n.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * Builds a human-readable notification message for each order status.
+     * The message is stored once at creation time so the customer sees the same
+     * text regardless of future order edits.
+     *
+     * @param orderId   order ID to include in the message
+     * @param newStatus the new order status
+     * @return ready-to-display notification string
+     */
+    private String buildMessage(Long orderId, OrderStatus newStatus) {
+        return switch (newStatus) {
+            case CONFIRMED      -> "Your order #" + orderId + " has been confirmed - payment received!";
+            case PROCESSING     -> "Your order #" + orderId + " is now being processed.";
+            case READY          -> "Your order #" + orderId + " is packed and ready to be dispatched.";
+            case OUT_FOR_DELIVERY -> "Your order #" + orderId + " is out for delivery!";
+            case DELIVERED      -> "Your order #" + orderId + " has been delivered. Enjoy!";
+            case RETURNED       -> "Your order #" + orderId + " has been returned and is under review.";
+            case CANCELLED      -> "Your order #" + orderId + " has been cancelled.";
+            // PENDING is the initial placement state - no notification needed for it
+            default             -> "Your order #" + orderId + " status updated to " + newStatus + ".";
+        };
+    }
+}

--- a/backend/src/main/java/com/urbanfresh/service/impl/OrderServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/OrderServiceImpl.java
@@ -42,6 +42,7 @@ import com.urbanfresh.repository.OrderRepository;
 import com.urbanfresh.repository.OrderStatusHistoryRepository;
 import com.urbanfresh.repository.ProductRepository;
 import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.NotificationService;
 import com.urbanfresh.service.OrderService;
 
 import lombok.RequiredArgsConstructor;
@@ -107,6 +108,7 @@ public class OrderServiceImpl implements OrderService {
         private final OrderStatusHistoryRepository orderStatusHistoryRepository;
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     /**
      * Places an order for the authenticated customer.
@@ -351,6 +353,8 @@ public class OrderServiceImpl implements OrderService {
                                                 .changeReason(normalizeChangeReason(request.getChangeReason()))
                                                 .build());
 
+                                notificationService.createOrderStatusNotification(updated, targetStatus);
+
                                 Order detailedUpdatedOrder = orderRepository
                                                 .findDetailedByIdAndAssignedDeliveryPersonId(orderId, deliveryPerson.getId())
                                                 .orElse(updated);
@@ -507,6 +511,8 @@ public class OrderServiceImpl implements OrderService {
                                 .changedByAdmin(adminUser)
                                 .changeReason(normalizedReason)
                                 .build());
+
+                notificationService.createOrderStatusNotification(updated, targetStatus);
 
                 return toAdminOrderResponse(updated);
         }
@@ -920,6 +926,11 @@ public class OrderServiceImpl implements OrderService {
                                 .changedByAdmin(adminUser)
                                 .changeReason("Assigned to delivery personnel: " + deliveryPerson.getName())
                                 .build());
+
+                // Only notify when the status actually changed (READY → OUT_FOR_DELIVERY)
+                if (updated.getStatus() != previousStatus) {
+                        notificationService.createOrderStatusNotification(updated, updated.getStatus());
+                }
 
                 return toAdminOrderResponse(updated);
         }

--- a/backend/src/main/java/com/urbanfresh/service/impl/PaymentServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/PaymentServiceImpl.java
@@ -32,6 +32,7 @@ import com.urbanfresh.repository.OrderRepository;
 import com.urbanfresh.repository.PaymentRepository;
 import com.urbanfresh.repository.UserRepository;
 import com.urbanfresh.service.LoyaltyService;
+import com.urbanfresh.service.NotificationService;
 import com.urbanfresh.service.PaymentService;
 
 import lombok.RequiredArgsConstructor;
@@ -78,6 +79,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;
     private final LoyaltyService loyaltyService;
+    private final NotificationService notificationService;
 
     /**
      * Creates a Stripe PaymentIntent for a customer-owned order.
@@ -400,6 +402,8 @@ public class PaymentServiceImpl implements PaymentService {
         order.setStatus(OrderStatus.CONFIRMED);
         order.setPaymentStatus(PaymentStatus.PAID);
         orderRepository.save(order);
+
+        notificationService.createOrderStatusNotification(order, OrderStatus.CONFIRMED);
 
         // Award loyalty points only now — payment is confirmed and the order is CONFIRMED.
         // Awarding here prevents customers from earning points on failed/cancelled payments.

--- a/backend/src/test/java/com/urbanfresh/service/NotificationOrderServiceTest.java
+++ b/backend/src/test/java/com/urbanfresh/service/NotificationOrderServiceTest.java
@@ -1,0 +1,176 @@
+package com.urbanfresh.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.urbanfresh.dto.request.OrderStatusUpdateRequest;
+import com.urbanfresh.model.Order;
+import com.urbanfresh.model.OrderStatus;
+import com.urbanfresh.model.PaymentStatus;
+import com.urbanfresh.model.Role;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.OrderRepository;
+import com.urbanfresh.repository.OrderStatusHistoryRepository;
+import com.urbanfresh.repository.ProductRepository;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.impl.OrderServiceImpl;
+
+/**
+ * Test Layer – Verifies notification creation at each order status change trigger point.
+ * Covers SCRUM-45 DoD: automated tests for notification creation logic.
+ *
+ * Three trigger paths are exercised here:
+ *   1. Admin updates order status via updateOrderStatus()
+ *   2. Delivery personnel updates order status via updateAssignedOrderStatusForDelivery()
+ *   3. Admin assigns delivery personnel, transitioning READY → OUT_FOR_DELIVERY
+ *
+ * Uses Mockito only — no Spring context loaded, so these run fast.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationOrderServiceTest {
+
+    @Mock private OrderRepository orderRepository;
+    @Mock private OrderStatusHistoryRepository orderStatusHistoryRepository;
+    @Mock private ProductRepository productRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private OrderServiceImpl orderService;
+
+    // ── Shared test fixtures ────────────────────────────────────────────────────
+
+    private final User customer = User.builder()
+            .id(1L).name("Jane Doe").email("jane@example.com").role(Role.CUSTOMER).build();
+
+    private final User adminUser = User.builder()
+            .id(10L).name("Admin").email("admin@test.com").role(Role.ADMIN).build();
+
+    private final User deliveryUser = User.builder()
+            .id(20L).name("Rider").email("rider@test.com").role(Role.DELIVERY).isActive(true).build();
+
+    // ── Trigger path 1: Admin status update ────────────────────────────────────
+
+    /**
+     * CONFIRMED → PROCESSING is a valid admin transition.
+     * Notification must be created for the customer with the new target status.
+     */
+    @Test
+    void updateOrderStatus_createsNotification_whenAdminAdvancesStatus() {
+        Order order = Order.builder()
+                .id(1L)
+                .customer(customer)
+                .status(OrderStatus.CONFIRMED)
+                .paymentStatus(PaymentStatus.PAID)
+                .totalAmount(BigDecimal.valueOf(3000))
+                .build();
+
+        OrderStatusUpdateRequest request = new OrderStatusUpdateRequest();
+        request.setStatus("PROCESSING");
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(userRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(adminUser));
+        when(orderRepository.save(order)).thenReturn(order);
+
+        orderService.updateOrderStatus(1L, request, "admin@test.com");
+
+        verify(notificationService).createOrderStatusNotification(order, OrderStatus.PROCESSING);
+    }
+
+    // ── Trigger path 2: Delivery personnel status update ──────────────────────
+
+    /**
+     * OUT_FOR_DELIVERY → DELIVERED is the normal delivery completion path.
+     * Notification must be created for the customer after the status is saved.
+     */
+    @Test
+    void updateAssignedOrderStatusForDelivery_createsNotification_whenStatusChanged() {
+        Order order = Order.builder()
+                .id(1L)
+                .customer(customer)
+                .status(OrderStatus.OUT_FOR_DELIVERY)
+                .paymentStatus(PaymentStatus.PAID)
+                .totalAmount(BigDecimal.valueOf(2500))
+                .assignedDeliveryPerson(deliveryUser)
+                .build();
+
+        OrderStatusUpdateRequest request = new OrderStatusUpdateRequest();
+        request.setStatus("DELIVERED");
+
+        when(userRepository.findByEmailAndRoleAndIsActiveTrue("rider@test.com", Role.DELIVERY))
+                .thenReturn(Optional.of(deliveryUser));
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(orderRepository.save(order)).thenReturn(order);
+        when(orderRepository.findDetailedByIdAndAssignedDeliveryPersonId(1L, deliveryUser.getId()))
+                .thenReturn(Optional.of(order));
+
+        orderService.updateAssignedOrderStatusForDelivery(1L, request, "rider@test.com");
+
+        verify(notificationService).createOrderStatusNotification(order, OrderStatus.DELIVERED);
+    }
+
+    // ── Trigger path 3: Assignment READY → OUT_FOR_DELIVERY ───────────────────
+
+    /**
+     * Assigning delivery personnel to a READY order transitions it to OUT_FOR_DELIVERY.
+     * Because the status changed a notification must be sent to the customer.
+     */
+    @Test
+    void assignDeliveryPersonnel_createsNotification_whenReadyTransitionsToOutForDelivery() {
+        Order order = Order.builder()
+                .id(1L)
+                .customer(customer)
+                .status(OrderStatus.READY)
+                .paymentStatus(PaymentStatus.PAID)
+                .totalAmount(BigDecimal.valueOf(1800))
+                .build();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(userRepository.findByIdAndRole(deliveryUser.getId(), Role.DELIVERY))
+                .thenReturn(Optional.of(deliveryUser));
+        when(userRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(adminUser));
+        when(orderRepository.save(order)).thenReturn(order);
+
+        orderService.assignDeliveryPersonnel(1L, deliveryUser.getId(), "admin@test.com");
+
+        verify(notificationService).createOrderStatusNotification(order, OrderStatus.OUT_FOR_DELIVERY);
+    }
+
+    /**
+     * Reassigning a delivery person to an order that is already OUT_FOR_DELIVERY
+     * does not change the status, so NO notification should be created.
+     * This guards against spurious duplicate notifications on reassignment.
+     */
+    @Test
+    void assignDeliveryPersonnel_doesNotCreateNotification_whenStatusUnchanged() {
+        Order order = Order.builder()
+                .id(1L)
+                .customer(customer)
+                .status(OrderStatus.OUT_FOR_DELIVERY)
+                .paymentStatus(PaymentStatus.PAID)
+                .totalAmount(BigDecimal.valueOf(1800))
+                .assignedDeliveryPerson(deliveryUser)
+                .build();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(userRepository.findByIdAndRole(deliveryUser.getId(), Role.DELIVERY))
+                .thenReturn(Optional.of(deliveryUser));
+        when(userRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(adminUser));
+        when(orderRepository.save(order)).thenReturn(order);
+
+        orderService.assignDeliveryPersonnel(1L, deliveryUser.getId(), "admin@test.com");
+
+        verify(notificationService, never()).createOrderStatusNotification(any(), any());
+    }
+}

--- a/backend/src/test/java/com/urbanfresh/service/NotificationPaymentServiceTest.java
+++ b/backend/src/test/java/com/urbanfresh/service/NotificationPaymentServiceTest.java
@@ -1,0 +1,125 @@
+package com.urbanfresh.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.urbanfresh.model.Order;
+import com.urbanfresh.model.OrderStatus;
+import com.urbanfresh.model.Payment;
+import com.urbanfresh.model.PaymentStatus;
+import com.urbanfresh.model.Role;
+import com.urbanfresh.model.User;
+import com.urbanfresh.repository.OrderRepository;
+import com.urbanfresh.repository.PaymentRepository;
+import com.urbanfresh.repository.UserRepository;
+import com.urbanfresh.service.impl.PaymentServiceImpl;
+
+/**
+ * Test Layer – Verifies notification creation for the payment confirmation flow.
+ * Covers SCRUM-45 DoD: automated test for the CONFIRMED notification trigger.
+ *
+ * applyPaidState() is a private method invoked by both the payment_intent.succeeded
+ * and charge.updated Stripe webhook paths. It is tested here via reflection to keep
+ * the test scope tight and avoid pulling in the Stripe SDK event-parsing stack.
+ *
+ * Uses Mockito only — no Spring context loaded, so these run fast.
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationPaymentServiceTest {
+
+    @Mock private OrderRepository orderRepository;
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private LoyaltyService loyaltyService;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private PaymentServiceImpl paymentService;
+
+    // ── Payment confirmation trigger ───────────────────────────────────────────
+
+    /**
+     * When applyPaidState() runs for a PENDING order it must:
+     *   1. Mark the payment as PAID and save it
+     *   2. Mark the order as CONFIRMED and save it
+     *   3. Fire a CONFIRMED notification for the customer
+     *   4. Award loyalty points (delegated to LoyaltyService — not the focus here)
+     *
+     * The method is reached via reflection to avoid constructing a real Stripe Event.
+     */
+    @Test
+    void applyPaidState_createsConfirmedNotification_whenOrderNotYetConfirmed() throws Exception {
+        User customer = User.builder()
+                .id(1L).name("Jane Doe").email("jane@example.com").role(Role.CUSTOMER).build();
+
+        Order order = Order.builder()
+                .id(42L)
+                .customer(customer)
+                .status(OrderStatus.PENDING)
+                .paymentStatus(PaymentStatus.PENDING)
+                .totalAmount(BigDecimal.valueOf(5000))
+                .build();
+
+        Payment payment = Payment.builder()
+                .id(1L)
+                .order(order)
+                .stripePaymentIntentId("pi_test_123")
+                .amount(BigDecimal.valueOf(5000))
+                .build();
+
+        when(orderRepository.save(order)).thenReturn(order);
+        when(paymentRepository.save(payment)).thenReturn(payment);
+
+        // Invoke the private applyPaidState method directly via reflection.
+        Method applyPaidState = PaymentServiceImpl.class.getDeclaredMethod(
+                "applyPaidState", Payment.class, String.class, String.class);
+        applyPaidState.setAccessible(true);
+        applyPaidState.invoke(paymentService, payment, "pi_test_123", "payment_intent.succeeded");
+
+        verify(notificationService).createOrderStatusNotification(order, OrderStatus.CONFIRMED);
+    }
+
+    /**
+     * Idempotency guard: if the order is already CONFIRMED when applyPaidState() is
+     * called (e.g. duplicate webhook event), no notification must be fired and no
+     * repositories must be touched for the status transition.
+     */
+    @Test
+    void applyPaidState_doesNotCreateNotification_whenOrderAlreadyConfirmed() throws Exception {
+        User customer = User.builder()
+                .id(1L).name("Jane Doe").email("jane@example.com").role(Role.CUSTOMER).build();
+
+        Order order = Order.builder()
+                .id(42L)
+                .customer(customer)
+                .status(OrderStatus.CONFIRMED)   // already confirmed — duplicate event
+                .paymentStatus(PaymentStatus.PAID)
+                .totalAmount(BigDecimal.valueOf(5000))
+                .build();
+
+        Payment payment = Payment.builder()
+                .id(1L)
+                .order(order)
+                .stripePaymentIntentId("pi_test_123")
+                .amount(BigDecimal.valueOf(5000))
+                .build();
+
+        Method applyPaidState = PaymentServiceImpl.class.getDeclaredMethod(
+                "applyPaidState", Payment.class, String.class, String.class);
+        applyPaidState.setAccessible(true);
+        applyPaidState.invoke(paymentService, payment, "pi_test_123", "payment_intent.succeeded");
+
+        verify(notificationService, org.mockito.Mockito.never())
+                .createOrderStatusNotification(any(), any());
+    }
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useCart } from '../context/CartContext';
+import NotificationBell from './NotificationBell';
 
 /**
  * Presentation Layer – Shared auth-aware navigation bar.
@@ -53,6 +54,9 @@ export default function Navbar() {
               <span className="inline-flex items-center justify-center w-5 h-5 bg-green-100 rounded-full text-green-600 text-xs">✓</span>
               Welcome back, {user?.name}!
             </span>
+
+            {/* Notification bell — visible to CUSTOMER only */}
+            {user?.role === 'CUSTOMER' && <NotificationBell />}
 
             {/* Cart shortcut — visible to CUSTOMER only */}
             {user?.role === 'CUSTOMER' && (

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react';
+import useNotifications from '../hooks/useNotifications';
+
+/**
+ * Presentation Layer – Notification bell for the nav bar.
+ * Self-contained: owns its own data via useNotifications.
+ * Shows a badge with the unread count and a dropdown list of notifications.
+ * CUSTOMER role only — Navbar controls whether this renders.
+ */
+export default function NotificationBell() {
+  const { notifications, unreadCount, loading, markRead, markAllRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+
+  // Close the dropdown when the user clicks outside the bell widget.
+  useEffect(() => {
+    function onOutsideClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onOutsideClick);
+    return () => document.removeEventListener('mousedown', onOutsideClick);
+  }, []);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {/* Bell trigger button */}
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative px-3 py-2 text-sm font-medium text-green-700 border border-green-600 rounded-lg hover:bg-green-50 transition-colors"
+        aria-label="Notifications"
+        aria-expanded={open}
+      >
+        🔔
+        {unreadCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center px-0.5">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown panel */}
+      {open && (
+        <div className="absolute right-0 mt-2 w-80 bg-white rounded-xl shadow-lg border border-gray-100 z-50">
+          {/* Header row */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+            <h3 className="text-sm font-semibold text-gray-800">Notifications</h3>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllRead}
+                className="text-xs text-green-600 hover:text-green-800 font-medium transition-colors"
+              >
+                Mark all as read
+              </button>
+            )}
+          </div>
+
+          {/* Notification list */}
+          <div className="max-h-72 overflow-y-auto divide-y divide-gray-50">
+            {loading ? (
+              <p className="text-center text-xs text-gray-400 py-8">Loading…</p>
+            ) : notifications.length === 0 ? (
+              <p className="text-center text-xs text-gray-400 py-8">No notifications yet</p>
+            ) : (
+              notifications.map((n) => (
+                <NotificationItem key={n.id} notification={n} onMarkRead={markRead} />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Single notification row shown inside the dropdown. */
+function NotificationItem({ notification, onMarkRead }) {
+  return (
+    <div
+      className={`px-4 py-3 flex items-start gap-3 ${
+        notification.read ? 'bg-white' : 'bg-green-50'
+      }`}
+    >
+      <span className="text-base mt-0.5" aria-hidden="true">
+        {notification.read ? '📭' : '📬'}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-gray-700 leading-snug">{notification.message}</p>
+        <p className="text-[10px] text-gray-400 mt-1">
+          {formatRelativeTime(notification.createdAt)}
+        </p>
+      </div>
+
+      {!notification.read && (
+        <button
+          onClick={() => onMarkRead(notification.id)}
+          className="text-[10px] text-green-600 hover:text-green-800 font-medium whitespace-nowrap mt-0.5 transition-colors"
+        >
+          Mark read
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Converts an ISO datetime string to a human-readable relative label. */
+function formatRelativeTime(isoString) {
+  if (!isoString) return '';
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getMyNotifications,
+  getUnreadCount,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from '../services/notificationService';
+
+/**
+ * Loads notifications for the authenticated customer and exposes helpers to
+ * mark individual or all notifications as read.
+ */
+export default function useNotifications() {
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const loadNotifications = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [items, count] = await Promise.all([getMyNotifications(), getUnreadCount()]);
+      setNotifications(Array.isArray(items) ? items : []);
+      setUnreadCount(typeof count === 'number' ? count : 0);
+    } catch (err) {
+      setError(err?.response?.status === 403 ? 'forbidden' : 'failed');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadNotifications();
+  }, [loadNotifications]);
+
+  const markRead = useCallback(async (notificationId) => {
+    try {
+      const updated = await markNotificationRead(notificationId);
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === updated.id ? updated : n))
+      );
+      setUnreadCount((prev) => Math.max(0, prev - 1));
+    } catch {
+      // silently ignore — badge will re-sync on next full refresh
+    }
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    try {
+      await markAllNotificationsRead();
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+      setUnreadCount(0);
+    } catch {
+      // silently ignore
+    }
+  }, []);
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    error,
+    refresh: loadNotifications,
+    markRead,
+    markAllRead,
+  };
+}

--- a/frontend/src/pages/customer/CustomerDashboard.jsx
+++ b/frontend/src/pages/customer/CustomerDashboard.jsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../context/AuthContext';
 import { getMyOrders, getLoyaltyPoints } from '../../services/orderService';
 import { formatAmount } from '../../utils/priceUtils';
 import PaymentModal from '../../components/PaymentModal';
+import useNotifications from '../../hooks/useNotifications';
 
 /**
  * Presentation Layer – Customer dashboard page.
@@ -23,6 +24,8 @@ export default function CustomerDashboard() {
   const [loading, setLoading] = useState(true);
   const [paymentModalOpen, setPaymentModalOpen] = useState(false);
   const [selectedOrderForPayment, setSelectedOrderForPayment] = useState(null);
+
+  const { notifications, unreadCount, markRead, markAllRead } = useNotifications();
 
   /** Load orders and loyalty points in parallel on mount.
    * allSettled ensures partial success: if one call fails, the other section
@@ -95,6 +98,64 @@ export default function CustomerDashboard() {
               Logout
             </button>
           </div>
+        </div>
+
+        {/* ── Notifications Section ── */}
+        <div className="bg-white rounded-2xl shadow-sm p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-bold text-gray-800">
+              🔔 Notifications
+              {unreadCount > 0 && (
+                <span className="ml-2 inline-flex items-center justify-center min-w-[20px] h-5 bg-red-500 text-white text-xs font-bold rounded-full px-1">
+                  {unreadCount}
+                </span>
+              )}
+            </h2>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllRead}
+                className="text-xs text-green-600 hover:text-green-800 font-medium transition-colors"
+              >
+                Mark all as read
+              </button>
+            )}
+          </div>
+
+          {notifications.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-6">No notifications yet</p>
+          ) : (
+            <div className="space-y-2">
+              {notifications.map((n) => (
+                <div
+                  key={n.id}
+                  className={`flex items-start gap-3 rounded-xl px-4 py-3 ${
+                    n.read ? 'bg-gray-50' : 'bg-green-50 border border-green-100'
+                  }`}
+                >
+                  <span className="text-base mt-0.5" aria-hidden="true">
+                    {n.read ? '📭' : '📬'}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-gray-700 leading-snug">{n.message}</p>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {new Date(n.createdAt).toLocaleString('en-LK', {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })}
+                    </p>
+                  </div>
+                  {!n.read && (
+                    <button
+                      onClick={() => markRead(n.id)}
+                      className="text-xs text-green-600 hover:text-green-800 font-medium whitespace-nowrap mt-0.5 transition-colors"
+                    >
+                      Mark read
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* ── Loyalty Points Section ── */}

--- a/frontend/src/services/notificationService.js
+++ b/frontend/src/services/notificationService.js
@@ -1,0 +1,13 @@
+import api from './api';
+
+export const getMyNotifications = () =>
+  api.get('/api/notifications').then((res) => res.data);
+
+export const getUnreadCount = () =>
+  api.get('/api/notifications/unread-count').then((res) => res.data);
+
+export const markNotificationRead = (notificationId) =>
+  api.patch(`/api/notifications/${notificationId}/read`).then((res) => res.data);
+
+export const markAllNotificationsRead = () =>
+  api.post('/api/notifications/read-all');


### PR DESCRIPTION
### Summary
Implements In-App Notifications for Order Status Updates (SCRUM-45) so customers receive a notification each time their order status changes. Notifications are persisted in the database, and customers can view them in real time — as a bell dropdown in the navbar and as a dedicated section on their dashboard — with the ability to mark individual or all notifications as read.

---

### Changes

#### Backend
| File | Change |
|------|--------|
| `model/Notification.java` | New entity — `notifications` table with `id`, `customer` (FK → users, LAZY), `orderId` (Long), `message`, `isRead` (default `false`), `createdAt` (`@PrePersist`). Auto-created by Hibernate via `ddl-auto=update`. |
| `repository/NotificationRepository.java` | New repository — all queries ownership-scoped to `customerId`: `findByCustomerIdOrderByCreatedAtDesc`, `findByIdAndCustomerId` (ownership guard for single-fetch), `countByCustomerIdAndIsReadFalse`, `markAllReadByCustomerId` (bulk JPQL UPDATE to avoid loading entities). |
| `dto/response/NotificationResponse.java` | New DTO — `id`, `orderId`, `message`, `read`, `createdAt`. |
| `service/NotificationService.java` | New interface — declares 5 methods: `createOrderStatusNotification`, `getMyNotifications`, `countUnread`, `markAsRead`, `markAllAsRead`. |
| `exception/NotificationNotFoundException.java` | New exception — extends `RuntimeException`; thrown when a notification is not found for the requesting customer. |
| `service/impl/NotificationServiceImpl.java` | Implements all 5 service methods. `createOrderStatusNotification` builds a human-readable message via a switch on `OrderStatus`. `markAsRead` enforces ownership via `findByIdAndCustomerId` and no-ops if already read. `markAllAsRead` delegates to the bulk JPQL update. |
| `controller/NotificationController.java` | New controller — `GET /api/notifications`, `GET /api/notifications/unread-count`, `PATCH /api/notifications/{id}/read`, `POST /api/notifications/read-all`. All methods `@PreAuthorize("hasRole('CUSTOMER')")` as defence-in-depth. |
| `config/SecurityConfig.java` | Added `.requestMatchers("/api/notifications/**").authenticated()` so JWT is required at the URL-filter layer. |
| `exception/GlobalExceptionHandler.java` | Added `handleNotificationNotFound` handler → HTTP 404. |
| `service/impl/OrderServiceImpl.java` | Wired `NotificationService` — fires `createOrderStatusNotification` at 3 call sites: admin `updateOrderStatus`, delivery `updateAssignedOrderStatusForDelivery`, and `assignDeliveryPersonnel` (only when status transitions READY → OUT_FOR_DELIVERY). |
| `service/impl/PaymentServiceImpl.java` | Wired `NotificationService` — fires `createOrderStatusNotification(order, CONFIRMED)` in `applyPaidState` after the order is saved, before loyalty points are awarded. |

#### Frontend
| File | Change |
|------|--------|
| `services/notificationService.js` | New service — 4 functions: `getMyNotifications`, `getUnreadCount`, `markNotificationRead`, `markAllNotificationsRead`, each mapping to the corresponding REST endpoint via `api.js`. |
| `hooks/useNotifications.js` | New hook — parallel-fetches notification list and unread count on mount (`Promise.all`). Exposes `markRead` (optimistic single-item update) and `markAllRead` (sets all `read: true` locally), plus `loading`, `error`, and `refresh`. |
| `components/NotificationBell.jsx` | New component — bell icon with red unread badge. Clicking opens a dropdown panel with the full notification list, per-item "Mark read" buttons, a global "Mark all as read" action, and relative timestamps (e.g. "5m ago"). Closes on outside click. CUSTOMER role visibility controlled by the parent. |
| `components/Navbar.jsx` | Imported `NotificationBell`; renders it for `CUSTOMER` role only, positioned between the welcome badge and the cart icon. |
| `pages/customer/CustomerDashboard.jsx` | Imported `useNotifications`; added a Notifications section above Loyalty Points — displays the full list with read/unread styling, formatted timestamps, per-item "Mark read", and a global "Mark all as read" action. |

---

### API Endpoints Added
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/notifications` | CUSTOMER | Returns all notifications for the authenticated customer, newest first |
| GET | `/api/notifications/unread-count` | CUSTOMER | Returns the count of unread notifications |
| PATCH | `/api/notifications/{id}/read` | CUSTOMER | Marks a single notification as read (ownership enforced; no-op if already read) |
| POST | `/api/notifications/read-all` | CUSTOMER | Bulk-marks all notifications as read for the authenticated customer |

---

### Acceptance Criteria
- [x] Given an order status changes, When the admin or delivery personnel updates the status, Then a notification is persisted for the customer with a human-readable message
- [x] Given a payment is confirmed via Stripe webhook, When `applyPaidState` runs, Then a CONFIRMED notification is persisted for the customer
- [x] Given a customer views their dashboard, When the notifications section loads, Then all notifications are shown with read/unread visual distinction and formatted timestamps
- [x] Given a customer has unread notifications, When the navbar loads, Then the bell icon displays a red badge with the unread count
- [x] Given a customer clicks "Mark read" on a notification, When the action completes, Then the notification is updated locally without a full page reload
- [x] Given a customer clicks "Mark all as read", When the action completes, Then all notifications are marked read and the badge clears
- [x] Given a non-customer accesses any `/api/notifications/**` endpoint, When the request is processed, Then access is denied (HTTP 403) enforced at both URL-filter and method level
- [x] Notification ownership is enforced — customers can only read or mark their own notifications
- [x] Overall waste percentage computed against total approved inventory value; zero-division guarded