### PR TITLE
IMPROV : Enhance UI

### DIFF
--- a/backend/src/main/java/com/urbanfresh/dto/response/SupplierProductResponse.java
+++ b/backend/src/main/java/com/urbanfresh/dto/response/SupplierProductResponse.java
@@ -21,5 +21,6 @@ public class SupplierProductResponse {
     private BigDecimal price;
     private PricingUnit unit;
     private Integer stockQuantity;
+    private Integer reorderThreshold;
     private String approvalStatus;
 }

--- a/backend/src/main/java/com/urbanfresh/service/impl/SupplierServiceImpl.java
+++ b/backend/src/main/java/com/urbanfresh/service/impl/SupplierServiceImpl.java
@@ -94,6 +94,7 @@ public class SupplierServiceImpl implements SupplierService {
                         .price(product.getPrice())
                         .unit(product.getUnit())
                         .stockQuantity(product.getStockQuantity())
+                        .reorderThreshold(product.getReorderThreshold())
                         .approvalStatus(product.getApprovalStatus() != null ? product.getApprovalStatus().name() : "APPROVED")
                         .build())
                 .toList();

--- a/frontend/src/components/admin/ProductFormModal.jsx
+++ b/frontend/src/components/admin/ProductFormModal.jsx
@@ -118,9 +118,9 @@ export default function ProductFormModal({ product, brands, onSubmit, onClose, l
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-black/35 px-2 pb-0 pt-4 backdrop-blur-sm sm:items-start sm:px-4 sm:py-8">
-      <div className="my-auto w-full max-w-md rounded-t-2xl border border-[#e4ebe8] bg-white shadow-xl sm:rounded-2xl">
-        <div className="flex items-start justify-between border-b border-[#edf2ef] px-6 pb-4 pt-5">
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/35 backdrop-blur-sm sm:items-center sm:p-4">
+      <div className="flex w-full max-w-md flex-col rounded-t-2xl border border-[#e4ebe8] bg-white shadow-xl sm:rounded-2xl" style={{ maxHeight: 'min(92dvh, 680px)' }}>
+        <div className="flex shrink-0 items-start justify-between border-b border-[#edf2ef] px-6 pb-4 pt-5">
           <div>
             <h2 className="text-base font-semibold text-slate-900">{isEdit ? 'Edit Product' : 'Create Product'}</h2>
             <p className="mt-1 text-xs text-slate-500">Add core product details for inventory management.</p>
@@ -137,7 +137,7 @@ export default function ProductFormModal({ product, brands, onSubmit, onClose, l
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="max-h-[70dvh] space-y-4 overflow-y-auto px-6 py-5 sm:max-h-[75vh]">
+        <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto px-6 py-5 pb-[calc(1.25rem+env(safe-area-inset-bottom))]">
           <Field label="PRODUCT NAME">
             <input
               name="name"

--- a/frontend/src/pages/admin/AdminBrandsPage.jsx
+++ b/frontend/src/pages/admin/AdminBrandsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { FiTag, FiCheckCircle, FiTrendingUp, FiSearch } from 'react-icons/fi';
 import {
   createBrand,
   deleteBrand,
@@ -21,12 +22,22 @@ export default function AdminBrandsPage() {
 
   const [form, setForm] = useState({ name: '', code: '' });
   const [errors, setErrors] = useState({});
+  const [search, setSearch] = useState('');
+  const [filterStatus, setFilterStatus] = useState('all');
+  const [sortField, setSortField] = useState('name');
+  const [sortDir, setSortDir] = useState('asc');
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 10;
 
   const isEditMode = Boolean(editingBrand);
 
   useEffect(() => {
     loadBrands();
   }, []);
+
+  useEffect(() => {
+    setPage(0);
+  }, [search, filterStatus]);
 
   const loadBrands = async () => {
     setLoading(true);
@@ -45,6 +56,43 @@ export default function AdminBrandsPage() {
     () => brands.filter((brand) => brand.active).length,
     [brands],
   );
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+    setPage(0);
+  };
+
+  const filtered = useMemo(() => {
+    let result = [...brands];
+    const q = search.toLowerCase();
+    if (q) {
+      result = result.filter(
+        (b) =>
+          b.name?.toLowerCase().includes(q) ||
+          b.code?.toLowerCase().includes(q),
+      );
+    }
+    if (filterStatus === 'active') result = result.filter((b) => b.active);
+    if (filterStatus === 'inactive') result = result.filter((b) => !b.active);
+    result.sort((a, b) => {
+      let av = '';
+      let bv = '';
+      if (sortField === 'name') { av = a.name || ''; bv = b.name || ''; }
+      else if (sortField === 'code') { av = a.code || ''; bv = b.code || ''; }
+      else if (sortField === 'status') { av = a.active ? 'active' : 'inactive'; bv = b.active ? 'active' : 'inactive'; }
+      const cmp = av.localeCompare(bv);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return result;
+  }, [brands, search, filterStatus, sortField, sortDir]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paged = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   const openCreate = () => {
     setEditingBrand(null);
@@ -159,40 +207,70 @@ export default function AdminBrandsPage() {
         </button>
       }
     >
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <div className="rounded-xl border border-[#e4ebe8] bg-[#f4f7f6] px-4 py-3">
+          <FiTag className="mb-2 h-5 w-5 text-[#6f817b]" />
           <p className="text-xs uppercase tracking-wide text-[#6f817b]">Total Brands</p>
           <p className="mt-1 text-2xl font-bold text-[#153a30]">{brands.length}</p>
         </div>
         <div className="rounded-xl border border-[#e4ebe8] bg-[#eaf5ef] px-4 py-3">
+          <FiCheckCircle className="mb-2 h-5 w-5 text-[#0d4a38]" />
           <p className="text-xs uppercase tracking-wide text-[#0d4a38]">Active Brands</p>
           <p className="mt-1 text-2xl font-bold text-[#0d4a38]">{activeCount}</p>
         </div>
         <div className="rounded-xl border border-[#e4ebe8] bg-[url('https://images.unsplash.com/photo-1542838132-92c53300491e?auto=format&fit=crop&w=800&q=60')] bg-cover bg-center px-4 py-3 text-white">
+          <FiTrendingUp className="mb-2 h-5 w-5 text-white/80" />
           <p className="text-xs uppercase tracking-wide text-white/80">Partner Utilization</p>
           <p className="mt-1 text-2xl font-bold">{brands.length > 0 ? Math.round((activeCount / brands.length) * 100) : 0}%</p>
         </div>
       </section>
 
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-45 flex-1">
+          <FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8fa89f]" />
+          <input
+            type="search"
+            placeholder="Search by name or code..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-9 w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] pl-9 pr-3 text-sm text-[#5f7770] focus:outline-none"
+          />
+        </div>
+        <select
+          value={filterStatus}
+          onChange={(e) => setFilterStatus(e.target.value)}
+          className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+        >
+          <option value="all">All Statuses</option>
+          <option value="active">Active only</option>
+          <option value="inactive">Inactive only</option>
+        </select>
+        {!loading && (
+          <span className="text-xs text-[#6f817b]">{filtered.length} brand{filtered.length !== 1 ? 's' : ''}</span>
+        )}
+      </div>
+
       <section className="overflow-hidden rounded-2xl border border-[#e4ebe8] bg-white shadow-sm">
         {loading ? (
           <div className="p-8 text-center text-sm text-[#6f817b]">Loading brands...</div>
-        ) : brands.length === 0 ? (
-          <div className="p-8 text-center text-sm text-[#6f817b]">No brands found. Create your first brand.</div>
+        ) : filtered.length === 0 ? (
+          <div className="p-8 text-center text-sm text-[#6f817b]">
+            {brands.length === 0 ? 'No brands found. Create your first brand.' : 'No brands match your search or filter.'}
+          </div>
         ) : (
           <>
             <div className="hidden overflow-x-auto md:block">
               <table className="min-w-full text-sm">
                 <thead className="bg-[#f5f8f7] text-xs uppercase tracking-wide text-[#7a8a85]">
                   <tr>
-                    <th className="px-4 py-3 text-left">Name</th>
-                    <th className="px-4 py-3 text-left">Code</th>
-                    <th className="px-4 py-3 text-left">Status</th>
+                    <SortableHeader label="Name" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                    <SortableHeader label="Code" field="code" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                    <SortableHeader label="Status" field="status" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
                     <th className="px-4 py-3 text-left">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {brands.map((brand) => (
+                  {paged.map((brand) => (
                     <tr key={brand.id} className="border-t border-[#edf2f0]">
                       <td className="px-4 py-3 font-semibold text-[#1f3b32]">{brand.name}</td>
                       <td className="px-4 py-3 text-[#425d55]">{brand.code}</td>
@@ -229,7 +307,7 @@ export default function AdminBrandsPage() {
             </div>
 
             <div className="space-y-3 p-4 md:hidden">
-              {brands.map((brand) => (
+              {paged.map((brand) => (
                 <article key={brand.id} className="rounded-xl border border-[#edf2ef] bg-[#fbfdfc] p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div>
@@ -262,6 +340,29 @@ export default function AdminBrandsPage() {
                 </article>
               ))}
             </div>
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between border-t border-[#edf2f0] px-4 py-3">
+                <span className="text-xs text-[#6f817b]">
+                  Page {page + 1} of {totalPages} &middot; {filtered.length} brand{filtered.length !== 1 ? 's' : ''}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0}
+                    className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40"
+                  >
+                    Prev
+                  </button>
+                  <button
+                    onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                    disabled={page >= totalPages - 1}
+                    className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
           </>
         )}
       </section>
@@ -347,5 +448,20 @@ export default function AdminBrandsPage() {
         </div>
       )}
     </AdminDeliveryLayout>
+  );
+}
+
+function SortableHeader({ label, field, sortField, sortDir, onSort, className = '' }) {
+  const active = sortField === field;
+  return (
+    <th className={`cursor-pointer select-none px-4 py-3 text-left ${className}`} onClick={() => onSort(field)}>
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <span className="inline-flex flex-col leading-none text-[#aabdb6]">
+          <svg className={`h-2.5 w-2.5 ${active && sortDir === 'asc' ? 'text-[#0d4a38]' : ''}`} viewBox="0 0 10 6" fill="currentColor" aria-hidden="true"><path d="M5 0L0 6h10z" /></svg>
+          <svg className={`h-2.5 w-2.5 ${active && sortDir === 'desc' ? 'text-[#0d4a38]' : ''}`} viewBox="0 0 10 6" fill="currentColor" aria-hidden="true"><path d="M5 6L0 0h10z" /></svg>
+        </span>
+      </span>
+    </th>
   );
 }

--- a/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/frontend/src/pages/admin/AdminDashboard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { FiShoppingCart, FiTrendingUp, FiBox, FiUsers } from 'react-icons/fi';
 import adminDashboardService from '../../services/adminDashboardService';
 import { useAuth } from '../../context/AuthContext';
 import AdminDeliveryLayout from '../../components/admin/delivery/AdminDeliveryLayout';
@@ -38,7 +39,9 @@ const AdminDashboard = () => {
       label: 'Total Orders',
       value: dashboardData?.totalOrders || 0,
       hint: 'All-time customer orders',
-      tone: 'text-[#0d4a38]'
+      tone: 'text-[#0d4a38]',
+      icon: FiShoppingCart,
+      iconBg: 'bg-amber-100 text-amber-600',
     },
     {
       label: 'Total Revenue',
@@ -47,19 +50,25 @@ const AdminDashboard = () => {
         maximumFractionDigits: 2,
       })}`,
       hint: 'From confirmed orders',
-      tone: 'text-[#0d4a38]'
+      tone: 'text-[#0d4a38]',
+      icon: FiTrendingUp,
+      iconBg: 'bg-green-100 text-green-700',
     },
     {
       label: 'Total Products',
       value: dashboardData?.totalProductsCount || 0,
       hint: 'Active catalog items',
-      tone: 'text-slate-900'
+      tone: 'text-slate-900',
+      icon: FiBox,
+      iconBg: 'bg-blue-100 text-blue-700',
     },
     {
       label: 'Active Suppliers',
       value: dashboardData?.activeSuppliersCount || 0,
       hint: 'Registered suppliers',
-      tone: 'text-slate-900'
+      tone: 'text-slate-900',
+      icon: FiUsers,
+      iconBg: 'bg-purple-100 text-purple-700',
     },
   ];
 
@@ -76,7 +85,7 @@ const AdminDashboard = () => {
       )}
 
       {loading && (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
           {[1, 2, 3, 4].map((i) => (
             <div key={i} className="h-28 animate-pulse rounded-2xl border border-[#e4ebe8] bg-white" />
           ))}
@@ -97,12 +106,17 @@ const AdminDashboard = () => {
 
       {!loading && !error && (
         <>
-          <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <section className="grid grid-cols-2 gap-3 xl:grid-cols-4">
             {summaryCards.map((card) => (
               <article
                 key={card.label}
                 className="rounded-2xl border border-[#e4ebe8] bg-white p-5 shadow-sm"
               >
+                {card.icon && (
+                  <div className={`mb-3 inline-flex rounded-xl p-2.5 ${card.iconBg}`}>
+                    <card.icon className="h-5 w-5" />
+                  </div>
+                )}
                 <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{card.label}</p>
                 <p className={`mt-2 text-2xl font-bold sm:text-3xl ${card.tone}`}>{card.value}</p>
                 <p className="mt-2 text-xs text-slate-500">{card.hint}</p>

--- a/frontend/src/pages/admin/AdminExpiryPage.jsx
+++ b/frontend/src/pages/admin/AdminExpiryPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
+import { FiAlertCircle, FiAlertTriangle, FiClock } from 'react-icons/fi';
 import { getExpiryBuckets } from '../../services/adminExpiryService';
 import { applyProductDiscount } from '../../services/adminProductService';
 import AdminDeliveryLayout from '../../components/admin/delivery/AdminDeliveryLayout';
@@ -130,10 +131,10 @@ export default function AdminExpiryPage() {
         <div className="rounded-xl border border-[#f2cccc] bg-[#fdecee] p-4 text-sm text-[#b03a3a]">{error}</div>
       )}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <MetricCard label="Total Near-Expiry" value={buckets?.totalNearExpiryCount ?? 0} tone="slate" />
-        <MetricCard label="Critical (0-1 days)" value={buckets?.within1Day?.length ?? 0} tone="danger" />
-        <MetricCard label="Urgent (2-7 days)" value={buckets?.within7Days?.length ?? 0} tone="warning" />
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <MetricCard label="Total Near-Expiry" value={buckets?.totalNearExpiryCount ?? 0} tone="slate" icon={FiAlertCircle} />
+        <MetricCard label="Critical (0-1 days)" value={buckets?.within1Day?.length ?? 0} tone="danger" icon={FiAlertTriangle} />
+        <MetricCard label="Urgent (2-7 days)" value={buckets?.within7Days?.length ?? 0} tone="warning" icon={FiClock} />
       </section>
 
       {loading ? (
@@ -390,7 +391,7 @@ function BucketSection({
   );
 }
 
-function MetricCard({ label, value, tone }) {
+function MetricCard({ label, value, tone, icon: Icon }) {
   const toneClass =
     tone === 'danger'
       ? 'bg-[#fdecee] text-[#b03a3a]'
@@ -400,6 +401,7 @@ function MetricCard({ label, value, tone }) {
 
   return (
     <article className={`rounded-xl border border-[#e4ebe8] px-4 py-3 ${toneClass}`}>
+      {Icon && <Icon className="mb-2 h-5 w-5 opacity-80" />}
       <p className="text-xs font-semibold uppercase tracking-wide opacity-80">{label}</p>
       <p className="mt-1 text-2xl font-bold">{value}</p>
     </article>

--- a/frontend/src/pages/admin/AdminInventoryPage.jsx
+++ b/frontend/src/pages/admin/AdminInventoryPage.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import toast from 'react-hot-toast';
+import { FiDatabase, FiAlertTriangle, FiCheckCircle, FiSearch } from 'react-icons/fi';
 import { getInventory, updateInventory, getProductBatches } from '../../services/inventoryService';
 import { createPurchaseOrder } from '../../services/adminPurchaseOrderService';
 import AdminDeliveryLayout from '../../components/admin/delivery/AdminDeliveryLayout';
@@ -26,6 +27,14 @@ export default function AdminInventoryPage() {
   const [batchDrawerItem, setBatchDrawerItem] = useState(null);
   const [batches, setBatches] = useState([]);
   const [batchesLoading, setBatchesLoading] = useState(false);
+
+  const [search, setSearch] = useState('');
+  const [filterCategory, setFilterCategory] = useState('');
+  const [filterStatus, setFilterStatus] = useState('');
+  const [sortField, setSortField] = useState('productName');
+  const [sortDir, setSortDir] = useState('asc');
+  const [invPage, setInvPage] = useState(0);
+  const INV_PAGE_SIZE = 10;
 
   const fetchInventory = async () => {
     setLoading(true);
@@ -132,6 +141,43 @@ export default function AdminInventoryPage() {
   const healthyCount = inventory.length - lowStockCount;
   const totalQuantity = inventory.reduce((sum, item) => sum + Number(item.quantity || 0), 0);
 
+  const categories = useMemo(
+    () => [...new Set(inventory.map((i) => i.category).filter(Boolean))].sort(),
+    [inventory]
+  );
+
+  const filtered = useMemo(() => {
+    let list = inventory;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (i) => i.productName?.toLowerCase().includes(q) || i.category?.toLowerCase().includes(q)
+      );
+    }
+    if (filterCategory) list = list.filter((i) => i.category === filterCategory);
+    if (filterStatus === 'low') list = list.filter((i) => i.lowStock);
+    else if (filterStatus === 'healthy') list = list.filter((i) => !i.lowStock);
+    return [...list].sort((a, b) => {
+      let va = a[sortField] ?? '';
+      let vb = b[sortField] ?? '';
+      if (typeof va === 'string') { va = va.toLowerCase(); vb = vb.toLowerCase(); }
+      if (va < vb) return sortDir === 'asc' ? -1 : 1;
+      if (va > vb) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [inventory, search, filterCategory, filterStatus, sortField, sortDir]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { setInvPage(0); }, [search, filterCategory, filterStatus, sortField, sortDir]);
+
+  const totalInvPages = Math.max(1, Math.ceil(filtered.length / INV_PAGE_SIZE));
+  const pagedInventory = filtered.slice(invPage * INV_PAGE_SIZE, (invPage + 1) * INV_PAGE_SIZE);
+
+  const handleSort = (field) => {
+    if (sortField === field) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortField(field); setSortDir('asc'); }
+  };
+
   return (
     <AdminDeliveryLayout
       title="Inventory Management"
@@ -159,10 +205,10 @@ export default function AdminInventoryPage() {
         <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div>
       )}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <MetricCard label="Total Stock Units" value={totalQuantity} tone="default" />
-        <MetricCard label="Low Stock Items" value={lowStockCount} tone="red" />
-        <MetricCard label="Healthy Items" value={healthyCount} tone="green" />
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <MetricCard label="Total Stock Units" value={totalQuantity} tone="default" icon={FiDatabase} />
+        <MetricCard label="Low Stock Items" value={lowStockCount} tone="red" icon={FiAlertTriangle} />
+        <MetricCard label="Healthy Items" value={healthyCount} tone="green" icon={FiCheckCircle} />
       </section>
 
       <section className="rounded-2xl border border-[#e4ebe8] bg-white p-4 shadow-sm sm:p-6">
@@ -171,16 +217,49 @@ export default function AdminInventoryPage() {
           View and update quantity and reorder thresholds for all products.
         </p>
 
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <div className="relative min-w-45 flex-1">
+            <FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#5f7770]" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by product or category…"
+              className="w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] py-2 pl-9 pr-3 text-sm text-[#5f7770] focus:border-[#0d4a38] focus:outline-none"
+            />
+          </div>
+          <select
+            value={filterCategory}
+            onChange={(e) => setFilterCategory(e.target.value)}
+            className="rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 py-2 text-sm font-semibold text-[#5f7770] focus:border-[#0d4a38] focus:outline-none"
+          >
+            <option value="">All Categories</option>
+            {categories.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <select
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value)}
+            className="rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 py-2 text-sm font-semibold text-[#5f7770] focus:border-[#0d4a38] focus:outline-none"
+          >
+            <option value="">All Statuses</option>
+            <option value="low">Low Stock only</option>
+            <option value="healthy">In Stock only</option>
+          </select>
+          <span className="ml-auto text-xs text-[#6f817b]">
+            {filtered.length} result{filtered.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+
         <div className="mt-4 hidden overflow-x-auto rounded-xl border border-[#edf2ef] md:block">
           <table className="min-w-full text-sm">
             <thead className="bg-slate-50">
               <tr>
-                <th className={th}>Product</th>
-                <th className={th}>Category</th>
-                <th className={`${th} text-right`}>Quantity</th>
-                <th className={`${th} text-right`}>Reorder Threshold</th>
+                <SortableHeader label="Product" field="productName" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                <SortableHeader label="Category" field="category" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                <SortableHeader label="Quantity" field="quantity" sortField={sortField} sortDir={sortDir} onSort={handleSort} right />
+                <SortableHeader label="Reorder Threshold" field="reorderThreshold" sortField={sortField} sortDir={sortDir} onSort={handleSort} right />
                 <th className={th}>Status</th>
-                <th className={th}>Last Updated</th>
+                <SortableHeader label="Last Updated" field="updatedAt" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
                 <th className={th}>Updated By</th>
                 <th className={th}>Actions</th>
               </tr>
@@ -199,7 +278,7 @@ export default function AdminInventoryPage() {
                 ))}
 
               {!loading &&
-                inventory.map((item) => {
+                pagedInventory.map((item) => {
                   if (editItem?.productId === item.productId) {
                     return (
                       <tr key={item.productId} className="border-t border-[#edf2ef] bg-amber-50/70">
@@ -332,7 +411,7 @@ export default function AdminInventoryPage() {
             </tbody>
           </table>
 
-          {!loading && inventory.length === 0 && (
+          {!loading && filtered.length === 0 && (
             <div className="py-16 text-center text-sm text-slate-400">No products found.</div>
           )}
         </div>
@@ -343,12 +422,12 @@ export default function AdminInventoryPage() {
               <div key={i} className="h-28 animate-pulse rounded-xl bg-slate-100" />
             ))}
 
-          {!loading && inventory.length === 0 && (
+          {!loading && filtered.length === 0 && (
             <div className="rounded-xl border border-[#edf2ef] p-6 text-center text-sm text-slate-500">No products found.</div>
           )}
 
           {!loading &&
-            inventory.map((item) => (
+            pagedInventory.map((item) => (
               <article key={item.productId} className="rounded-xl border border-[#edf2ef] bg-[#fbfdfc] p-4">
                 <div className="flex items-start justify-between gap-3">
                   <div>
@@ -372,6 +451,24 @@ export default function AdminInventoryPage() {
               </article>
             ))}
         </div>
+
+        {!loading && totalInvPages > 1 && (
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-sm text-slate-600">
+            <span>Page {invPage + 1} of {totalInvPages} · {filtered.length} items</span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setInvPage((p) => p - 1)}
+                disabled={invPage === 0}
+                className="rounded-lg border border-[#d4dfdb] px-3 py-1.5 text-sm transition hover:bg-slate-50 disabled:opacity-40"
+              >Prev</button>
+              <button
+                onClick={() => setInvPage((p) => p + 1)}
+                disabled={invPage >= totalInvPages - 1}
+                className="rounded-lg border border-[#d4dfdb] px-3 py-1.5 text-sm transition hover:bg-slate-50 disabled:opacity-40"
+              >Next</button>
+            </div>
+          </div>
+        )}
       </section>
 
       {batchDrawerItem && (
@@ -386,7 +483,7 @@ export default function AdminInventoryPage() {
   );
 }
 
-function MetricCard({ label, value, tone }) {
+function MetricCard({ label, value, tone, icon: Icon }) {
   const toneClass =
     tone === 'red'
       ? 'bg-[#fdecee] text-red-700'
@@ -396,6 +493,7 @@ function MetricCard({ label, value, tone }) {
 
   return (
     <article className={`rounded-xl border border-[#e4ebe8] px-4 py-3 ${toneClass}`}>
+      {Icon && <Icon className="mb-2 h-5 w-5 opacity-80" />}
       <p className="text-xs font-semibold uppercase tracking-wide opacity-80">{label}</p>
       <p className="mt-1 text-2xl font-bold">{value}</p>
     </article>
@@ -471,6 +569,21 @@ function BatchDrawer({ item, batches, loading, onClose }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function SortableHeader({ label, field, sortField, sortDir, onSort, right }) {
+  const active = sortField === field;
+  const base = 'px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 cursor-pointer select-none';
+  return (
+    <th className={`${base} ${right ? 'text-right' : 'text-left'}`} onClick={() => onSort(field)}>
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <span className={active ? 'text-[#0d4a38]' : 'text-slate-300'}>
+          {active && sortDir === 'desc' ? '▼' : '▲'}
+        </span>
+      </span>
+    </th>
   );
 }
 

--- a/frontend/src/pages/admin/AdminOrdersPage.jsx
+++ b/frontend/src/pages/admin/AdminOrdersPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { FiShoppingBag, FiClock, FiDollarSign, FiCheckCircle } from 'react-icons/fi';
 import {
   assignDeliveryPersonnel,
   getActiveDeliveryPersonnel,
@@ -14,6 +15,7 @@ import DeliveryStatusBadge from '../../components/admin/delivery/DeliveryStatusB
 import DeliveryStatusConfirmModal from '../../components/admin/delivery/DeliveryStatusConfirmModal';
 
 const PAGE_SIZE = 20;
+const FILTERED_PAGE_SIZE = 8;
 
 /**
  * Presentation Layer – Admin order management page.
@@ -26,6 +28,7 @@ export default function AdminOrdersPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [updatingOrderId, setUpdatingOrderId] = useState(null);
+  const [filteredPage, setFilteredPage] = useState(0);
   const [pendingCorrection, setPendingCorrection] = useState(null);
   const [orderReviewOpen, setOrderReviewOpen] = useState(false);
   const [loadingOrderReview, setLoadingOrderReview] = useState(false);
@@ -184,6 +187,15 @@ export default function AdminOrdersPage() {
     [pageData, searchTerm, statusFilter]
   );
 
+  // Reset filtered page when search or filter changes
+  useEffect(() => { setFilteredPage(0); }, [searchTerm, statusFilter]);
+
+  const totalFilteredPages = Math.max(1, Math.ceil(filteredOrders.length / FILTERED_PAGE_SIZE));
+  const pagedFilteredOrders = filteredOrders.slice(
+    filteredPage * FILTERED_PAGE_SIZE,
+    (filteredPage + 1) * FILTERED_PAGE_SIZE
+  );
+
   const stats = useMemo(() => {
     const source = pageData?.content || [];
     const total = source.length;
@@ -249,11 +261,11 @@ export default function AdminOrdersPage() {
         }}
       />
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard label="Total Orders Today" value={String(stats.total)} note="+12% from yesterday" />
-        <MetricCard label="Pending Processing" value={String(stats.processing)} note="Requires action" />
-        <MetricCard label="Revenue (Daily)" value={`Rs. ${formatLkr(stats.revenue)}`} note="Healthy flow" />
-        <MetricCard label="Delivered" value={String(stats.delivered)} note="98% success rate" />
+      <section className="grid grid-cols-2 gap-4 xl:grid-cols-4">
+        <MetricCard label="Total Orders Today" value={String(stats.total)} note="+12% from yesterday" icon={FiShoppingBag} />
+        <MetricCard label="Pending Processing" value={String(stats.processing)} note="Requires action" icon={FiClock} />
+        <MetricCard label="Revenue (Daily)" value={`Rs. ${formatLkr(stats.revenue)}`} note="Healthy flow" icon={FiDollarSign} />
+        <MetricCard label="Delivered" value={String(stats.delivered)} note="98% success rate" icon={FiCheckCircle} />
       </section>
 
       <section className="rounded-2xl border border-[#e4ebe8] bg-white p-4 shadow-sm sm:p-5">
@@ -338,7 +350,7 @@ export default function AdminOrdersPage() {
                       </td>
                     </tr>
                   ) : (
-                    filteredOrders.map((order) => (
+                    pagedFilteredOrders.map((order) => (
                       <tr key={order.orderId} className="border-t border-[#edf2f0] align-top">
                         <td className={td}>#UF-ORD-{order.orderId}</td>
                         <td className={td}>
@@ -436,7 +448,7 @@ export default function AdminOrdersPage() {
                   />
                 </div>
               ) : (
-                filteredOrders.map((order) => (
+                pagedFilteredOrders.map((order) => (
                   <article key={order.orderId} className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
@@ -509,26 +521,49 @@ export default function AdminOrdersPage() {
               )}
             </div>
 
-            {pageData.totalPages > 1 && (
+            {(totalFilteredPages > 1 || pageData.totalPages > 1) && (
               <div className="mt-4 flex flex-col gap-3 text-sm text-[#6f817b] sm:flex-row sm:items-center sm:justify-between">
                 <span>
-                  Page {pageData.number + 1} of {pageData.totalPages} - {pageData.totalElements ?? 0} orders total
+                  Showing {filteredOrders.length === 0 ? 0 : filteredPage * FILTERED_PAGE_SIZE + 1}–{Math.min((filteredPage + 1) * FILTERED_PAGE_SIZE, filteredOrders.length)} of {filteredOrders.length} orders
+                  {pageData.totalPages > 1 && ` (page ${pageData.number + 1}/${pageData.totalPages} loaded)`}
                 </span>
                 <div className="flex gap-2">
-                  <button
-                    onClick={() => setCurrentPage((value) => value - 1)}
-                    disabled={pageData.first}
-                    className="rounded-lg border border-[#d5dfdb] bg-white px-3 py-1.5 font-medium text-[#526b64] transition hover:bg-[#f2f7f5] disabled:opacity-50"
-                  >
-                    Prev
-                  </button>
-                  <button
-                    onClick={() => setCurrentPage((value) => value + 1)}
-                    disabled={pageData.last}
-                    className="rounded-lg border border-[#d5dfdb] bg-white px-3 py-1.5 font-medium text-[#526b64] transition hover:bg-[#f2f7f5] disabled:opacity-50"
-                  >
-                    Next
-                  </button>
+                  {pageData.totalPages > 1 && (
+                    <>
+                      <button
+                        onClick={() => { setCurrentPage((v) => v - 1); setFilteredPage(0); }}
+                        disabled={pageData.first}
+                        className="rounded-lg border border-[#d5dfdb] bg-white px-3 py-1.5 font-medium text-[#526b64] transition hover:bg-[#f2f7f5] disabled:opacity-50"
+                      >
+                        Load Prev
+                      </button>
+                      <button
+                        onClick={() => { setCurrentPage((v) => v + 1); setFilteredPage(0); }}
+                        disabled={pageData.last}
+                        className="rounded-lg border border-[#d5dfdb] bg-white px-3 py-1.5 font-medium text-[#526b64] transition hover:bg-[#f2f7f5] disabled:opacity-50"
+                      >
+                        Load Next
+                      </button>
+                    </>
+                  )}
+                  {totalFilteredPages > 1 && (
+                    <>
+                      <button
+                        onClick={() => setFilteredPage((p) => p - 1)}
+                        disabled={filteredPage === 0}
+                        className="rounded-lg border border-[#d5dfdb] bg-white px-3 py-1.5 font-medium text-[#526b64] transition hover:bg-[#f2f7f5] disabled:opacity-50"
+                      >
+                        Prev
+                      </button>
+                      <button
+                        onClick={() => setFilteredPage((p) => p + 1)}
+                        disabled={filteredPage >= totalFilteredPages - 1}
+                        className="rounded-lg border border-[#d5dfdb] bg-white px-3 py-1.5 font-medium text-[#526b64] transition hover:bg-[#f2f7f5] disabled:opacity-50"
+                      >
+                        Next
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
             )}
@@ -622,9 +657,14 @@ function OrdersEmptyState({ searchTerm, statusFilter, onReset }) {
   );
 }
 
-function MetricCard({ label, value, note }) {
+function MetricCard({ label, value, note, icon: Icon }) {
   return (
     <article className="rounded-2xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
+      {Icon && (
+        <div className="mb-3 inline-flex rounded-xl bg-[#eaf5ef] p-2.5 text-[#0d4a38]">
+          <Icon className="h-5 w-5" />
+        </div>
+      )}
       <p className="text-sm font-medium text-[#6f817b]">{label}</p>
       <p className="mt-1 text-4xl font-bold tracking-tight text-[#133b31]">{value}</p>
       <p className="mt-1 text-sm text-[#58957a]">{note}</p>

--- a/frontend/src/pages/admin/AdminProductsPage.jsx
+++ b/frontend/src/pages/admin/AdminProductsPage.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { toast } from 'react-hot-toast';
+import { FiPackage, FiEye, FiEyeOff, FiSearch } from 'react-icons/fi';
 import {
   getAdminProducts,
   createProduct,
@@ -22,13 +23,20 @@ import { formatPrice } from '../../utils/priceUtils';
 export default function AdminProductsPage() {
   const [activeTab, setActiveTab] = useState('catalog');
 
-  const [pageData, setPageData] = useState(null);
+  const [allProducts, setAllProducts] = useState([]);
   const [pendingData, setPendingData] = useState(null);
-  const [currentPage, setCurrentPage] = useState(0);
   const [currentPendingPage, setCurrentPendingPage] = useState(0);
   const [loadingTable, setLoadingTable] = useState(false);
   const [tableError, setTableError] = useState(null);
   const [brands, setBrands] = useState([]);
+
+  const [search, setSearch] = useState('');
+  const [filterCategory, setFilterCategory] = useState('');
+  const [filterStatus, setFilterStatus] = useState('');
+  const [sortField, setSortField] = useState('name');
+  const [sortDir, setSortDir] = useState('asc');
+  const [catalogPage, setCatalogPage] = useState(0);
+  const CATALOG_PAGE_SIZE = 10;
 
   const [modalOpen, setModalOpen] = useState(false);
   const [editProduct, setEditProduct] = useState(null);
@@ -42,11 +50,11 @@ export default function AdminProductsPage() {
     setTableError(null);
     try {
       const [data, pData, activeBrands] = await Promise.all([
-        getAdminProducts(currentPage, 20),
+        getAdminProducts(0, 1000),
         getPendingProducts(currentPendingPage, 20),
         getActiveBrands(),
       ]);
-      setPageData(data);
+      setAllProducts(data.content || []);
       setPendingData(pData);
       setBrands(activeBrands);
     } catch {
@@ -54,7 +62,7 @@ export default function AdminProductsPage() {
     } finally {
       setLoadingTable(false);
     }
-  }, [currentPage, currentPendingPage]);
+  }, [currentPendingPage]);
 
   useEffect(() => {
     fetchPage();
@@ -100,11 +108,7 @@ export default function AdminProductsPage() {
     try {
       const updated = await toggleHideProduct(product.id);
       toast.success(updated.hidden ? 'Product hidden from store' : 'Product visible in store');
-      setPageData((prev) =>
-        prev
-          ? { ...prev, content: prev.content.map((p) => (p.id === updated.id ? updated : p)) }
-          : prev
-      );
+      setAllProducts((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
     } catch {
       toast.error('Failed to update product visibility');
     } finally {
@@ -138,9 +142,49 @@ export default function AdminProductsPage() {
     }
   };
 
-  const pageSummary = pageData?.content || [];
-  const hiddenCount = pageSummary.filter((item) => item.hidden).length;
-  const visibleCount = pageSummary.length - hiddenCount;
+  const hiddenCount = allProducts.filter((p) => p.hidden).length;
+  const visibleCount = allProducts.length - hiddenCount;
+
+  const categories = useMemo(
+    () => [...new Set(allProducts.map((p) => p.category).filter(Boolean))].sort(),
+    [allProducts]
+  );
+
+  const filtered = useMemo(() => {
+    let list = allProducts;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (p) =>
+          p.name?.toLowerCase().includes(q) ||
+          p.category?.toLowerCase().includes(q) ||
+          p.brandName?.toLowerCase().includes(q)
+      );
+    }
+    if (filterCategory) list = list.filter((p) => p.category === filterCategory);
+    if (filterStatus === 'hidden') list = list.filter((p) => p.hidden);
+    else if (filterStatus === 'visible') list = list.filter((p) => !p.hidden);
+    return [...list].sort((a, b) => {
+      let va = a[sortField] ?? '';
+      let vb = b[sortField] ?? '';
+      if (typeof va === 'string') va = va.toLowerCase();
+      if (typeof vb === 'string') vb = vb.toLowerCase();
+      if (va < vb) return sortDir === 'asc' ? -1 : 1;
+      if (va > vb) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }, [allProducts, search, filterCategory, filterStatus, sortField, sortDir]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { setCatalogPage(0); }, [search, filterCategory, filterStatus, sortField, sortDir]);
+
+  const totalCatalogPages = Math.max(1, Math.ceil(filtered.length / CATALOG_PAGE_SIZE));
+  const pagedProducts = filtered.slice(catalogPage * CATALOG_PAGE_SIZE, (catalogPage + 1) * CATALOG_PAGE_SIZE);
+
+  const handleSort = (field) => {
+    if (sortField === field) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortField(field); setSortDir('asc'); }
+  };
 
   return (
     <AdminDeliveryLayout
@@ -160,10 +204,10 @@ export default function AdminProductsPage() {
         <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{tableError}</div>
       )}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <SummaryCard label="Loaded Products" value={pageData?.totalElements ?? 0} tone="default" />
-        <SummaryCard label="Visible in Store" value={visibleCount} tone="green" />
-        <SummaryCard label="Hidden from Store" value={hiddenCount} tone="slate" />
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <SummaryCard label="Total Products" value={allProducts.length} tone="default" icon={FiPackage} />
+        <SummaryCard label="Visible in Store" value={visibleCount} tone="green" icon={FiEye} />
+        <SummaryCard label="Hidden from Store" value={hiddenCount} tone="slate" icon={FiEyeOff} />
       </section>
 
       <section className="rounded-2xl border border-[#e4ebe8] bg-white p-4 shadow-sm sm:p-6">
@@ -203,31 +247,64 @@ export default function AdminProductsPage() {
           </div>
         )}
 
-        {!loadingTable && activeTab === 'catalog' && pageData && (
+        {!loadingTable && activeTab === 'catalog' && (
           <>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <div className="relative min-w-45 flex-1">
+                <FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#5f7770]" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search by name, category or brand…"
+                  className="w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] py-2 pl-9 pr-3 text-sm text-[#5f7770] focus:border-[#0d4a38] focus:outline-none"
+                />
+              </div>
+              <select
+                value={filterCategory}
+                onChange={(e) => setFilterCategory(e.target.value)}
+                className="rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 py-2 text-sm font-semibold text-[#5f7770] focus:border-[#0d4a38] focus:outline-none"
+              >
+                <option value="">All Categories</option>
+                {categories.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+              <select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value)}
+                className="rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 py-2 text-sm font-semibold text-[#5f7770] focus:border-[#0d4a38] focus:outline-none"
+              >
+                <option value="">All Statuses</option>
+                <option value="visible">Visible only</option>
+                <option value="hidden">Hidden only</option>
+              </select>
+              <span className="ml-auto text-xs text-[#6f817b]">
+                {filtered.length} result{filtered.length !== 1 ? 's' : ''}
+              </span>
+            </div>
+
             <div className="mt-4 hidden overflow-x-auto rounded-xl border border-[#edf2ef] md:block">
               <table className="min-w-full text-sm">
                 <thead className="bg-slate-50">
                   <tr>
-                    <th className={th}>Name</th>
-                    <th className={th}>Category</th>
-                    <th className={th}>Brand</th>
-                    <th className={th}>Price</th>
-                    <th className={th}>Stock</th>
+                    <SortableHeader label="Name" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                    <SortableHeader label="Category" field="category" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                    <SortableHeader label="Brand" field="brandName" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                    <SortableHeader label="Price" field="price" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                    <SortableHeader label="Stock" field="stockQuantity" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
                     <th className={th}>Status</th>
-                    <th className={th}>Expiry</th>
+                    <SortableHeader label="Expiry" field="earliestExpiryDate" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
                     <th className={th}>Actions</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {pageData.content?.length === 0 ? (
+                  {pagedProducts.length === 0 ? (
                     <tr>
                       <td colSpan={8} className="px-4 py-10 text-center text-slate-400">
                         No products found.
                       </td>
                     </tr>
                   ) : (
-                    pageData.content?.map((p) => (
+                    pagedProducts.map((p) => (
                       <tr key={p.id} className="border-t border-[#edf2ef]">
                         <td className={td}><span className="font-medium text-slate-900">{p.name}</span></td>
                         <td className={td}>{p.category ?? '—'}</td>
@@ -277,12 +354,12 @@ export default function AdminProductsPage() {
             </div>
 
             <div className="mt-4 space-y-3 md:hidden">
-              {pageData.content?.length === 0 ? (
+              {pagedProducts.length === 0 ? (
                 <div className="rounded-xl border border-[#edf2ef] p-6 text-center text-sm text-slate-500">
                   No products found.
                 </div>
               ) : (
-                pageData.content?.map((p) => (
+                pagedProducts.map((p) => (
                   <article key={p.id} className="rounded-xl border border-[#edf2ef] bg-[#fbfdfc] p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
@@ -317,11 +394,23 @@ export default function AdminProductsPage() {
               )}
             </div>
 
-            <Pagination
-              pageData={pageData}
-              onPrev={() => setCurrentPage((p) => p - 1)}
-              onNext={() => setCurrentPage((p) => p + 1)}
-            />
+            {totalCatalogPages > 1 && (
+              <div className="mt-4 flex flex-wrap items-center justify-between gap-2 text-sm text-slate-600">
+                <span>Page {catalogPage + 1} of {totalCatalogPages} · {filtered.length} products</span>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setCatalogPage((p) => p - 1)}
+                    disabled={catalogPage === 0}
+                    className="rounded-lg border border-[#d4dfdb] px-3 py-1.5 text-sm transition hover:bg-slate-50 disabled:opacity-40"
+                  >Prev</button>
+                  <button
+                    onClick={() => setCatalogPage((p) => p + 1)}
+                    disabled={catalogPage >= totalCatalogPages - 1}
+                    className="rounded-lg border border-[#d4dfdb] px-3 py-1.5 text-sm transition hover:bg-slate-50 disabled:opacity-40"
+                  >Next</button>
+                </div>
+              </div>
+            )}
           </>
         )}
 
@@ -447,7 +536,7 @@ export default function AdminProductsPage() {
   );
 }
 
-function SummaryCard({ label, value, tone }) {
+function SummaryCard({ label, value, tone, icon: Icon }) {
   const toneClass =
     tone === 'green'
       ? 'bg-[#eaf5ef] text-[#0d4a38]'
@@ -457,6 +546,7 @@ function SummaryCard({ label, value, tone }) {
 
   return (
     <article className={`rounded-xl border border-[#e4ebe8] px-4 py-3 ${toneClass}`}>
+      {Icon && <Icon className="mb-2 h-5 w-5 opacity-80" />}
       <p className="text-xs font-semibold uppercase tracking-wide opacity-80">{label}</p>
       <p className="mt-1 text-2xl font-bold">{value}</p>
     </article>
@@ -501,6 +591,20 @@ function Pagination({ pageData, onPrev, onNext }) {
         </button>
       </div>
     </div>
+  );
+}
+
+function SortableHeader({ label, field, sortField, sortDir, onSort, className }) {
+  const active = sortField === field;
+  return (
+    <th className={`${className} cursor-pointer select-none`} onClick={() => onSort(field)}>
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <span className={active ? 'text-[#0d4a38]' : 'text-slate-300'}>
+          {active && sortDir === 'desc' ? '▼' : '▲'}
+        </span>
+      </span>
+    </th>
   );
 }
 

--- a/frontend/src/pages/admin/AdminPurchaseOrdersPage.jsx
+++ b/frontend/src/pages/admin/AdminPurchaseOrdersPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import AdminDeliveryLayout from '../../components/admin/delivery/AdminDeliveryLayout';
 import { confirmDeliveryAndStock, getAllPurchaseOrders } from '../../services/adminPurchaseOrderService';
@@ -10,6 +11,9 @@ export default function AdminPurchaseOrdersPage() {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState('ALL');
+  const [search, setSearch] = useState('');
+  const [sortField, setSortField] = useState('id');
+  const [sortDir, setSortDir] = useState('desc');
   const [currentPage, setCurrentPage] = useState(1);
 
   const PAGE_SIZE = 4;
@@ -21,6 +25,8 @@ export default function AdminPurchaseOrdersPage() {
   useEffect(() => {
     void loadOrders();
   }, []);
+
+  useEffect(() => { setCurrentPage(1); }, [activeFilter, search]);
 
   const loadOrders = async () => {
     setLoading(true);
@@ -93,9 +99,25 @@ export default function AdminPurchaseOrdersPage() {
   );
 
   const filteredOrders = useMemo(() => {
-    if (activeFilter === 'ALL') return orders;
-    return orders.filter((order) => order.status === activeFilter);
-  }, [activeFilter, orders]);
+    let result = activeFilter === 'ALL' ? [...orders] : orders.filter((o) => o.status === activeFilter);
+    const q = search.toLowerCase();
+    if (q) {
+      result = result.filter(
+        (o) =>
+          `PO-${o.id}`.toLowerCase().includes(q) ||
+          (o.brandName || '').toLowerCase().includes(q) ||
+          (o.items || []).some((item) => item.productName?.toLowerCase().includes(q)),
+      );
+    }
+    result.sort((a, b) => {
+      if (sortField === 'id') return sortDir === 'asc' ? a.id - b.id : b.id - a.id;
+      const av = sortField === 'brand' ? (a.brandName || '') : (a.status || '');
+      const bv = sortField === 'brand' ? (b.brandName || '') : (b.status || '');
+      const cmp = av.localeCompare(bv);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return result;
+  }, [activeFilter, orders, search, sortField, sortDir]);
 
   const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
 
@@ -114,6 +136,17 @@ export default function AdminPurchaseOrdersPage() {
         { label: 'Inventory', to: '/admin/inventory' },
         { label: 'Purchase Orders' },
       ]}
+      actions={
+        <Link
+          to="/admin/inventory"
+          className="inline-flex items-center gap-2 rounded-xl border border-[#d4dfdb] bg-white px-4 py-2 text-sm font-semibold text-[#0d4a38] transition hover:bg-[#f1f6f4]"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Inventory
+        </Link>
+      }
     >
       {confirmOrderId && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4 py-6 backdrop-blur-sm">
@@ -222,16 +255,6 @@ export default function AdminPurchaseOrdersPage() {
       <section className="rounded-2xl border border-[#e4ebe8] bg-white shadow-sm">
         <div className="flex flex-col gap-4 border-b border-[#edf2f0] px-4 py-4 sm:px-5">
           <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              className="inline-flex items-center gap-2 rounded-xl bg-[#9be7bf] px-3 py-2 text-sm font-semibold text-[#0d4a38]"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M6 12h12m-8 6h4" />
-              </svg>
-              Filters
-            </button>
-
             {[
               { key: 'ALL', label: `All POs (${statusCount.ALL})` },
               { key: 'PENDING', label: 'Pending' },
@@ -254,8 +277,36 @@ export default function AdminPurchaseOrdersPage() {
                 {filterItem.label}
               </button>
             ))}
+          </div>
 
-            <span className="ml-auto text-xs text-[#6f817b]">Last updated: Just now</span>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="relative min-w-48 flex-1">
+              <svg className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8fa89f]" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="11" cy="11" r="8" /><path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35" />
+              </svg>
+              <input
+                type="search"
+                placeholder="Search by PO#, brand or item..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="h-9 w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] pl-9 pr-3 text-sm text-[#5f7770] focus:outline-none"
+              />
+            </div>
+            <select
+              value={`${sortField}:${sortDir}`}
+              onChange={(e) => {
+                const [f, d] = e.target.value.split(':');
+                setSortField(f); setSortDir(d); setCurrentPage(1);
+              }}
+              className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+            >
+              <option value="id:desc">Newest first</option>
+              <option value="id:asc">Oldest first</option>
+              <option value="brand:asc">Brand A–Z</option>
+              <option value="brand:desc">Brand Z–A</option>
+              <option value="status:asc">Status A–Z</option>
+            </select>
+            <span className="ml-auto text-xs text-[#6f817b]">{filteredOrders.length} order{filteredOrders.length !== 1 ? 's' : ''}</span>
           </div>
         </div>
 
@@ -281,7 +332,7 @@ export default function AdminPurchaseOrdersPage() {
               ) : filteredOrders.length === 0 ? (
                 <tr>
                   <td className="px-4 py-10 text-sm text-[#6f817b] sm:px-5" colSpan={6}>
-                    No purchase orders found.
+                    {orders.length === 0 ? 'No purchase orders found.' : 'No orders match your search or filter.'}
                   </td>
                 </tr>
               ) : (
@@ -328,7 +379,7 @@ export default function AdminPurchaseOrdersPage() {
           {loading ? (
             <p className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4 text-sm text-[#6f817b]">Loading purchase orders...</p>
           ) : filteredOrders.length === 0 ? (
-            <p className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4 text-sm text-[#6f817b]">No purchase orders found.</p>
+            <p className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4 text-sm text-[#6f817b]">{orders.length === 0 ? 'No purchase orders found.' : 'No orders match your search or filter.'}</p>
           ) : (
             pagedOrders.map((order) => (
               <article key={order.id} className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4">

--- a/frontend/src/pages/admin/AdminPurchaseOrdersPage.jsx
+++ b/frontend/src/pages/admin/AdminPurchaseOrdersPage.jsx
@@ -10,6 +10,9 @@ export default function AdminPurchaseOrdersPage() {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState('ALL');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const PAGE_SIZE = 4;
   const [confirmOrderId, setConfirmOrderId] = useState(null);
   const [confirmOrderItems, setConfirmOrderItems] = useState([]);
   const [batchFormData, setBatchFormData] = useState({});
@@ -76,16 +79,15 @@ export default function AdminPurchaseOrdersPage() {
     }));
   };
 
-  const noticedOrders = useMemo(
-    () => orders.filter((order) => order.status === 'CANCELLED' && order.supplierNotice),
-    [orders]
-  );
-
   const statusCount = useMemo(
     () => ({
       ALL: orders.length,
       PENDING: orders.filter((order) => order.status === 'PENDING').length,
+      ACCEPTED: orders.filter((order) => order.status === 'ACCEPTED').length,
       SHIPPED: orders.filter((order) => order.status === 'SHIPPED').length,
+      DELIVERED: orders.filter((order) => order.status === 'DELIVERED').length,
+      COMPLETED: orders.filter((order) => order.status === 'COMPLETED').length,
+      CANCELLED: orders.filter((order) => order.status === 'CANCELLED').length,
     }),
     [orders]
   );
@@ -94,6 +96,13 @@ export default function AdminPurchaseOrdersPage() {
     if (activeFilter === 'ALL') return orders;
     return orders.filter((order) => order.status === activeFilter);
   }, [activeFilter, orders]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
+
+  const pagedOrders = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return filteredOrders.slice(start, start + PAGE_SIZE);
+  }, [filteredOrders, currentPage]);
 
   return (
     <AdminDeliveryLayout
@@ -208,35 +217,7 @@ export default function AdminPurchaseOrdersPage() {
         </div>
       )}
 
-      {noticedOrders.length > 0 && (
-        <section className="rounded-2xl border border-[#f3c8c8] bg-[#fdecee] px-5 py-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <p className="text-sm font-semibold text-[#ba2f2f]">Supplier Attention Required</p>
-              <p className="text-xs text-[#8f4040]">
-                {noticedOrders
-                  .slice(0, 3)
-                  .map((order) => `${order.brandName} (${order.id})`)
-                  .join(', ')}
-                {noticedOrders.length > 3 ? ' and others have reported delays.' : ' have reported stock delays.'}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                const firstOrderWithReason =
-                  noticedOrders.find((order) => order.supplierNotice) || noticedOrders[0];
-                setViewReason(
-                  firstOrderWithReason?.supplierNotice || firstOrderWithReason?.rejectionReason || 'No reason provided'
-                );
-              }}
-              className="text-xs font-semibold text-[#a22f2f] underline decoration-[#e5a9a9] underline-offset-2"
-            >
-              View Details
-            </button>
-          </div>
-        </section>
-      )}
+
 
       <section className="rounded-2xl border border-[#e4ebe8] bg-white shadow-sm">
         <div className="flex flex-col gap-4 border-b border-[#edf2f0] px-4 py-4 sm:px-5">
@@ -254,12 +235,16 @@ export default function AdminPurchaseOrdersPage() {
             {[
               { key: 'ALL', label: `All POs (${statusCount.ALL})` },
               { key: 'PENDING', label: 'Pending' },
+              { key: 'ACCEPTED', label: 'Accepted' },
               { key: 'SHIPPED', label: 'Shipped' },
+              { key: 'DELIVERED', label: 'Delivered' },
+              { key: 'COMPLETED', label: 'Completed' },
+              { key: 'CANCELLED', label: 'Cancelled' },
             ].map((filterItem) => (
               <button
                 key={filterItem.key}
                 type="button"
-                onClick={() => setActiveFilter(filterItem.key)}
+                onClick={() => { setActiveFilter(filterItem.key); setCurrentPage(1); }}
                 className={`rounded-xl px-3 py-2 text-xs font-semibold transition ${
                   activeFilter === filterItem.key
                     ? 'bg-[#0d4a38] text-white'
@@ -300,7 +285,7 @@ export default function AdminPurchaseOrdersPage() {
                   </td>
                 </tr>
               ) : (
-                filteredOrders.map((order) => (
+                pagedOrders.map((order) => (
                   <tr key={order.id} className="border-t border-[#edf2f0] align-top">
                     <td className="px-4 py-4 text-sm font-semibold text-[#1d3a31] sm:px-5">PO-{order.id}</td>
                     <td className="px-4 py-4 text-sm font-semibold text-[#1d3a31] sm:px-5">{order.brandName}</td>
@@ -330,9 +315,7 @@ export default function AdminPurchaseOrdersPage() {
                         >
                           Rationale
                         </button>
-                      ) : (
-                        <span className="text-sm font-semibold text-[#18483a]">Track</span>
-                      )}
+                      ) : null}
                     </td>
                   </tr>
                 ))
@@ -347,7 +330,7 @@ export default function AdminPurchaseOrdersPage() {
           ) : filteredOrders.length === 0 ? (
             <p className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4 text-sm text-[#6f817b]">No purchase orders found.</p>
           ) : (
-            filteredOrders.map((order) => (
+            pagedOrders.map((order) => (
               <article key={order.id} className="rounded-2xl border border-[#e4ebe8] bg-[#f8fbf9] p-4">
                 <div className="mb-2 flex items-start justify-between gap-3">
                   <p className="text-sm font-semibold text-[#153a30]">PO-{order.id}</p>
@@ -375,9 +358,7 @@ export default function AdminPurchaseOrdersPage() {
                     >
                       View Rationale
                     </button>
-                  ) : (
-                    <p className="text-xs font-semibold text-[#18483a]">Track</p>
-                  )}
+                  ) : null}
                 </div>
               </article>
             ))
@@ -386,51 +367,41 @@ export default function AdminPurchaseOrdersPage() {
 
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[#edf2f0] px-4 py-4 text-xs text-[#6f817b] sm:px-5">
           <span>
-            Showing 1-{Math.min(filteredOrders.length, 4)} of {filteredOrders.length} purchase orders
+            Showing {filteredOrders.length === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1}–{Math.min(currentPage * PAGE_SIZE, filteredOrders.length)} of {filteredOrders.length} purchase orders
           </span>
           <div className="flex items-center gap-2">
-            <button className="h-7 w-7 rounded-lg border border-[#d8e2de] text-[#5f7770]" type="button" aria-label="Previous page">
+            <button
+              className="h-7 w-7 rounded-lg border border-[#d8e2de] text-[#5f7770] disabled:opacity-40"
+              type="button"
+              aria-label="Previous page"
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+            >
               &lt;
             </button>
-            <button className="h-7 min-w-7 rounded-lg bg-[#0d4a38] px-2 text-xs font-semibold text-white" type="button">
-              1
-            </button>
-            <button className="h-7 min-w-7 rounded-lg border border-[#d8e2de] px-2 text-xs font-semibold text-[#5f7770]" type="button">
-              2
-            </button>
-            <button className="h-7 w-7 rounded-lg border border-[#d8e2de] text-[#5f7770]" type="button" aria-label="Next page">
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+              <button
+                key={page}
+                type="button"
+                onClick={() => setCurrentPage(page)}
+                className={`h-7 min-w-7 rounded-lg px-2 text-xs font-semibold ${
+                  page === currentPage
+                    ? 'bg-[#0d4a38] text-white'
+                    : 'border border-[#d8e2de] text-[#5f7770] hover:bg-[#f1f6f4]'
+                }`}
+              >
+                {page}
+              </button>
+            ))}
+            <button
+              className="h-7 w-7 rounded-lg border border-[#d8e2de] text-[#5f7770] disabled:opacity-40"
+              type="button"
+              aria-label="Next page"
+              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+            >
               &gt;
             </button>
-          </div>
-        </div>
-      </section>
-
-      <section className="grid gap-4 xl:grid-cols-[1.05fr_1.8fr]">
-        <div className="rounded-3xl bg-[linear-gradient(145deg,#083a2c,#0d4a38)] p-5 text-white shadow-[0_20px_32px_rgba(7,45,35,0.35)]">
-          <p className="text-sm text-white/80">Total Outflow</p>
-          <p className="mt-2 text-4xl font-bold tracking-tight">Rs. 2,84,500</p>
-          <p className="mt-2 text-xs text-[#b7dccd]">+12.5% from last month</p>
-          <p className="mt-4 text-xs text-[#d2ece2]">3 active suppliers this week</p>
-        </div>
-
-        <div className="rounded-2xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
-          <h3 className="text-2xl font-semibold text-[#153a30]">Inventory Replenishment Status</h3>
-          <p className="text-xs text-[#7a8a85]">Real-time status of items currently in transit</p>
-
-          <div className="mt-4 space-y-4">
-            <ProgressRow label="Perishables" percent={85} />
-            <ProgressRow label="Dairy & Poultry" percent={42} />
-          </div>
-
-          <div className="mt-4 flex flex-wrap items-center gap-4 text-xs text-[#5f7770]">
-            <span className="inline-flex items-center gap-1.5">
-              <span className="h-2 w-2 rounded-full bg-[#0d4a38]" />
-              On Track
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span className="h-2 w-2 rounded-full bg-[#be2f2f]" />
-              Delayed (3)
-            </span>
           </div>
         </div>
       </section>
@@ -453,19 +424,5 @@ function StatusBadge({ status }) {
     <span className={`inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.07em] ${tones[normalized] || 'bg-[#e8efec] text-[#4f6a62]'}`}>
       {normalized || 'UNKNOWN'}
     </span>
-  );
-}
-
-function ProgressRow({ label, percent }) {
-  return (
-    <div>
-      <div className="mb-1 flex items-center justify-between text-[11px] font-semibold uppercase tracking-widest text-[#61766f]">
-        <span>{label}</span>
-        <span>{percent}%</span>
-      </div>
-      <div className="h-2 rounded-full bg-[#e7efeb]">
-        <div className="h-2 rounded-full bg-[#0d4a38]" style={{ width: `${percent}%` }} />
-      </div>
-    </div>
   );
 }

--- a/frontend/src/pages/admin/AdminSuppliersPage.jsx
+++ b/frontend/src/pages/admin/AdminSuppliersPage.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { FiUsers, FiUserCheck, FiTag, FiSearch } from 'react-icons/fi';
 import {
   createSupplier,
   getActiveBrands,
@@ -22,9 +23,58 @@ export default function AdminSuppliersPage() {
   const [editingSupplier, setEditingSupplier] = useState(null);
   const [modalError, setModalError] = useState('');
 
+  const [search, setSearch] = useState('');
+  const [filterStatus, setFilterStatus] = useState('all');
+  const [sortField, setSortField] = useState('name');
+  const [sortDir, setSortDir] = useState('asc');
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 10;
+
   useEffect(() => {
     loadData();
   }, []);
+
+  useEffect(() => {
+    setPage(0);
+  }, [search, filterStatus]);
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+    setPage(0);
+  };
+
+  const filtered = useMemo(() => {
+    let result = [...suppliers];
+    const q = search.toLowerCase();
+    if (q) {
+      result = result.filter(
+        (s) =>
+          s.name?.toLowerCase().includes(q) ||
+          s.email?.toLowerCase().includes(q) ||
+          s.brands?.some((b) => b.name?.toLowerCase().includes(q)),
+      );
+    }
+    if (filterStatus === 'active') result = result.filter((s) => s.isActive);
+    if (filterStatus === 'inactive') result = result.filter((s) => !s.isActive);
+    result.sort((a, b) => {
+      let av = '';
+      let bv = '';
+      if (sortField === 'name') { av = a.name || ''; bv = b.name || ''; }
+      else if (sortField === 'email') { av = a.email || ''; bv = b.email || ''; }
+      else if (sortField === 'status') { av = a.isActive ? 'active' : 'inactive'; bv = b.isActive ? 'active' : 'inactive'; }
+      const cmp = av.localeCompare(bv);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return result;
+  }, [suppliers, search, filterStatus, sortField, sortDir]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paged = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   const loadData = async () => {
     setLoading(true);
@@ -137,18 +187,21 @@ export default function AdminSuppliersPage() {
         </button>
       }
     >
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         <div className="rounded-xl border border-[#e4ebe8] bg-[#f4f7f6] px-4 py-3">
+          <FiUsers className="mb-2 h-5 w-5 text-[#6f817b]" />
           <p className="text-xs uppercase tracking-wide text-[#6f817b]">Total Suppliers</p>
           <p className="mt-1 text-2xl font-bold text-[#153a30]">{suppliers.length}</p>
         </div>
         <div className="rounded-xl border border-[#e4ebe8] bg-[#eaf5ef] px-4 py-3">
+          <FiUserCheck className="mb-2 h-5 w-5 text-[#0d4a38]" />
           <p className="text-xs uppercase tracking-wide text-[#0d4a38]">Active Suppliers</p>
           <p className="mt-1 text-2xl font-bold text-[#0d4a38]">
             {suppliers.filter((supplier) => supplier.isActive).length}
           </p>
         </div>
         <div className="rounded-xl border border-[#e4ebe8] bg-[#dff4e8] px-4 py-3">
+          <FiTag className="mb-2 h-5 w-5 text-[#0d4a38]" />
           <p className="text-xs uppercase tracking-wide text-[#0d4a38]">Active Brands Available</p>
           <p className="mt-1 text-2xl font-bold text-[#0d4a38]">{brands.length}</p>
         </div>
@@ -165,26 +218,53 @@ export default function AdminSuppliersPage() {
         />
       )}
 
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-45 flex-1">
+          <FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8fa89f]" />
+          <input
+            type="search"
+            placeholder="Search by name, email or brand..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-9 w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] pl-9 pr-3 text-sm text-[#5f7770] focus:outline-none"
+          />
+        </div>
+        <select
+          value={filterStatus}
+          onChange={(e) => setFilterStatus(e.target.value)}
+          className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+        >
+          <option value="all">All Statuses</option>
+          <option value="active">Active only</option>
+          <option value="inactive">Inactive only</option>
+        </select>
+        {!loading && (
+          <span className="text-xs text-[#6f817b]">{filtered.length} supplier{filtered.length !== 1 ? 's' : ''}</span>
+        )}
+      </div>
+
       <section className="overflow-hidden rounded-2xl border border-[#e4ebe8] bg-white shadow-sm">
         {loading ? (
           <div className="p-10 text-center text-[#6f817b]">Loading supplier accounts...</div>
-        ) : suppliers.length === 0 ? (
-          <div className="p-10 text-center text-[#6f817b]">No suppliers found. Create one to get started.</div>
+        ) : filtered.length === 0 ? (
+          <div className="p-10 text-center text-[#6f817b]">
+            {suppliers.length === 0 ? 'No suppliers found. Create one to get started.' : 'No suppliers match your search or filter.'}
+          </div>
         ) : (
           <>
             <div className="hidden overflow-x-auto md:block">
               <table className="min-w-full text-sm">
                 <thead className="bg-[#f5f8f7] text-xs uppercase tracking-wide text-[#7a8a85]">
                   <tr>
-                    <th className="px-4 py-3 text-left">Name</th>
-                    <th className="px-4 py-3 text-left">Email</th>
+                    <SortableHeader label="Name" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                    <SortableHeader label="Email" field="email" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
                     <th className="px-4 py-3 text-left">Brands</th>
-                    <th className="px-4 py-3 text-left">Status</th>
+                    <SortableHeader label="Status" field="status" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
                     <th className="px-4 py-3 text-left">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {suppliers.map((supplier) => (
+                  {paged.map((supplier) => (
                     <tr key={supplier.id} className="border-t border-[#edf2f0]">
                       <td className="px-4 py-3 font-semibold text-[#1f3b32]">{supplier.name}</td>
                       <td className="px-4 py-3 text-[#425d55]">{supplier.email}</td>
@@ -227,7 +307,7 @@ export default function AdminSuppliersPage() {
             </div>
 
             <div className="space-y-3 p-4 md:hidden">
-              {suppliers.map((supplier) => (
+              {paged.map((supplier) => (
                 <article key={supplier.id} className="rounded-xl border border-[#edf2ef] bg-[#fbfdfc] p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div>
@@ -266,9 +346,47 @@ export default function AdminSuppliersPage() {
                 </article>
               ))}
             </div>
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between border-t border-[#edf2f0] px-4 py-3">
+                <span className="text-xs text-[#6f817b]">
+                  Page {page + 1} of {totalPages} &middot; {filtered.length} supplier{filtered.length !== 1 ? 's' : ''}
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    disabled={page === 0}
+                    className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40"
+                  >
+                    Prev
+                  </button>
+                  <button
+                    onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                    disabled={page >= totalPages - 1}
+                    className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
           </>
         )}
       </section>
     </AdminDeliveryLayout>
+  );
+}
+
+function SortableHeader({ label, field, sortField, sortDir, onSort, className = '' }) {
+  const active = sortField === field;
+  return (
+    <th className={`cursor-pointer select-none px-4 py-3 text-left ${className}`} onClick={() => onSort(field)}>
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <span className="inline-flex flex-col leading-none text-[#aabdb6]">
+          <svg className={`h-2.5 w-2.5 ${active && sortDir === 'asc' ? 'text-[#0d4a38]' : ''}`} viewBox="0 0 10 6" fill="currentColor" aria-hidden="true"><path d="M5 0L0 6h10z" /></svg>
+          <svg className={`h-2.5 w-2.5 ${active && sortDir === 'desc' ? 'text-[#0d4a38]' : ''}`} viewBox="0 0 10 6" fill="currentColor" aria-hidden="true"><path d="M5 6L0 0h10z" /></svg>
+        </span>
+      </span>
+    </th>
   );
 }

--- a/frontend/src/pages/admin/AdminWasteReportPage.jsx
+++ b/frontend/src/pages/admin/AdminWasteReportPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
+import { FiTrash2, FiPackage } from 'react-icons/fi';
 import {
   BarChart,
   Bar,
@@ -72,7 +73,7 @@ export default function AdminWasteReportPage() {
 
       {loading ? (
         <div className="space-y-4">
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="grid grid-cols-2 gap-4">
             {[1, 2].map((i) => (
               <div key={i} className="h-24 animate-pulse rounded-2xl border border-[#e4ebe8] bg-white" />
             ))}
@@ -82,9 +83,9 @@ export default function AdminWasteReportPage() {
         </div>
       ) : (
         <>
-          <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <MetricCard icon="Waste Value" label="Total Waste Value" value={formatAmount(totalWasteValue)} tone="danger" />
-            <MetricCard icon="Units" label="Total Wasted Units" value={Number(totalWastedUnits).toLocaleString()} tone="warning" />
+          <section className="grid grid-cols-2 gap-4">
+            <MetricCard icon={<FiTrash2 className="h-5 w-5" />} label="Total Waste Value" value={formatAmount(totalWasteValue)} tone="danger" />
+            <MetricCard icon={<FiPackage className="h-5 w-5" />} label="Total Wasted Units" value={Number(totalWastedUnits).toLocaleString()} tone="warning" />
           </section>
 
           <section className="rounded-2xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
@@ -201,7 +202,7 @@ function MetricCard({ icon, label, value, tone }) {
 
   return (
     <article className={`rounded-xl border border-[#e4ebe8] px-4 py-3 ${toneClass}`}>
-      <p className="text-xs font-semibold uppercase tracking-wide opacity-80">{icon}</p>
+      {icon && <span className="mb-2 inline-block opacity-80">{icon}</span>}
       <p className="mt-1 text-sm font-medium opacity-90">{label}</p>
       <p className="mt-1 text-2xl font-bold">{value}</p>
     </article>

--- a/frontend/src/pages/admin/DeliveryPersonnelPage.jsx
+++ b/frontend/src/pages/admin/DeliveryPersonnelPage.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { FiUserCheck, FiUserX, FiTruck } from 'react-icons/fi';
 import {
   createDeliveryPersonnel,
   getDeliveryPersonnelList,
@@ -280,7 +281,7 @@ export default function DeliveryPersonnelPage() {
               </button>
             </div>
 
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-2">
               <InfoCard label="Email" value={selectedPerson.email} />
               <InfoCard label="Phone" value={selectedPerson.phone || 'Not provided'} />
               <InfoCard
@@ -409,10 +410,10 @@ export default function DeliveryPersonnelPage() {
           </div>
         </div>
 
-        <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <MetricCard label="Active Personnel" value={activeCount} tone="green" />
-          <MetricCard label="Inactive Personnel" value={inactiveCount} tone="slate" />
-          <MetricCard label="Total Fleet" value={allPersonnel.length} tone="mint" />
+        <div className="mt-5 grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <MetricCard label="Active Personnel" value={activeCount} tone="green" icon={FiUserCheck} />
+          <MetricCard label="Inactive Personnel" value={inactiveCount} tone="slate" icon={FiUserX} />
+          <MetricCard label="Total Fleet" value={allPersonnel.length} tone="mint" icon={FiTruck} />
         </div>
 
         <div className="mt-5 overflow-hidden rounded-xl border border-[#e4ebe8]">
@@ -557,7 +558,7 @@ async function getOrdersForDeliveryPerson(deliveryPersonId) {
   return collected;
 }
 
-function MetricCard({ label, value, tone }) {
+function MetricCard({ label, value, tone, icon: Icon }) {
   const cardToneByKey = {
     slate: 'bg-[#f4f7f6] text-[#425d55]',
     green: 'bg-[#eaf5ef] text-[#0d4a38]',
@@ -572,6 +573,7 @@ function MetricCard({ label, value, tone }) {
 
   return (
     <div className={`rounded-xl border border-[#e4ebe8] px-4 py-3 ${cardToneByKey[tone] || cardToneByKey.slate}`}>
+      {Icon && <Icon className="mb-2 h-5 w-5 opacity-80" />}
       <p className="text-xs uppercase tracking-wide opacity-80">{label}</p>
       <p className={`mt-1 text-2xl font-bold ${valueToneByKey[tone] || valueToneByKey.slate}`}>{value}</p>
     </div>

--- a/frontend/src/pages/customer/LoyaltyHistoryPage.jsx
+++ b/frontend/src/pages/customer/LoyaltyHistoryPage.jsx
@@ -75,7 +75,7 @@ export default function LoyaltyHistoryPage() {
       breadcrumbItems={[{ label: 'Dashboard', to: '/dashboard' }, { label: 'Loyalty' }]}
       rightAside={rightAside}
     >
-      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <section className="grid grid-cols-2 gap-4">
         <div className="rounded-2xl border border-[#cae3d6] bg-[#eaf5ef] p-5">
           <p className="text-xs uppercase tracking-wide text-[#5f7f72]">Total Points</p>
           <p className="mt-2 text-4xl font-semibold text-[#163a2f]">{loading ? '-' : Number(loyalty?.totalPoints || 0)}</p>

--- a/frontend/src/pages/delivery/DeliveryCurrentOrdersPage.jsx
+++ b/frontend/src/pages/delivery/DeliveryCurrentOrdersPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 import { FiMapPin } from 'react-icons/fi';
@@ -16,19 +16,29 @@ export default function DeliveryCurrentOrdersPage() {
   const { logout } = useAuth();
   const { currentOrders, loading, error, refreshOrders } = useDeliveryOrders();
   const [searchValue, setSearchValue] = useState('');
+  const [sortDir, setSortDir] = useState('desc');
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 8;
 
   const filteredOrders = useMemo(() => {
-    const normalizedSearch = searchValue.trim().toLowerCase();
-
-    return currentOrders.filter((order) => {
-      if (!normalizedSearch) return true;
-
+    const q = searchValue.trim().toLowerCase();
+    let result = currentOrders.filter((order) => {
+      if (!q) return true;
       return (
-        String(order.orderId).includes(normalizedSearch) ||
-        String(order.customerName || '').toLowerCase().includes(normalizedSearch)
+        String(order.orderId).includes(q) ||
+        String(order.customerName || '').toLowerCase().includes(q)
       );
     });
-  }, [currentOrders, searchValue]);
+    result = [...result].sort((a, b) =>
+      sortDir === 'desc' ? b.orderId - a.orderId : a.orderId - b.orderId,
+    );
+    return result;
+  }, [currentOrders, searchValue, sortDir]);
+
+  useEffect(() => { setPage(0); }, [searchValue]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
+  const pagedOrders = filteredOrders.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   const handleOpenOrder = (orderId) => {
     navigate(`/delivery/orders/${orderId}`);
@@ -97,9 +107,19 @@ export default function DeliveryCurrentOrdersPage() {
       </section>
 
       <section className="mt-4 rounded-3xl border border-[#e4ebe8] bg-white p-4 shadow-sm sm:p-6">
-        <div className="mb-3 flex items-end justify-between gap-2">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
           <h3 className="text-2xl font-semibold leading-tight text-[#0d3f31] sm:text-3xl">Active Orders</h3>
-          <p className="text-sm font-medium text-[#8a9993]">Total active: {currentOrders.length}</p>
+          <div className="flex items-center gap-2">
+            <select
+              value={sortDir}
+              onChange={(e) => { setSortDir(e.target.value); setPage(0); }}
+              className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+            >
+              <option value="desc">Newest first</option>
+              <option value="asc">Oldest first</option>
+            </select>
+            <p className="text-sm font-medium text-[#8a9993]">{filteredOrders.length} order{filteredOrders.length !== 1 ? 's' : ''}</p>
+          </div>
         </div>
 
         {loading && <p className="mt-4 text-sm text-slate-500">Loading orders...</p>}
@@ -107,17 +127,54 @@ export default function DeliveryCurrentOrdersPage() {
         {!loading && error === 'failed' && <p className="mt-4 text-sm text-slate-700">Failed to load orders. Please refresh.</p>}
 
         {!loading && !error && filteredOrders.length === 0 && (
-          <p className="mt-4 text-sm text-slate-500">No newly assigned orders match your search.</p>
+          <p className="mt-4 text-sm text-slate-500">
+            {currentOrders.length === 0 ? 'No active orders at the moment.' : 'No orders match your search.'}
+          </p>
         )}
 
         {!loading && !error && filteredOrders.length > 0 && (
           <ul className="mt-4 space-y-3">
-            {filteredOrders.map((delivery) => (
+            {pagedOrders.map((delivery) => (
               <li key={delivery.orderId}>
                 <DeliveryOrderCard delivery={delivery} onOpen={handleOpenOrder} showNewlyAssigned />
               </li>
             ))}
           </ul>
+        )}
+
+        {!loading && !error && totalPages > 1 && (
+          <div className="mt-5 flex items-center justify-center gap-1">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#dce8e3] bg-white text-[#0d4a38] disabled:opacity-30"
+            >
+              ‹
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setPage(i)}
+                className={`flex h-10 min-w-10 items-center justify-center rounded-xl border px-2 text-sm font-semibold transition ${
+                  i === page
+                    ? 'border-[#0d4a38] bg-[#0d4a38] text-white'
+                    : 'border-[#dce8e3] bg-white text-[#4a6259] hover:bg-[#f1f6f4]'
+                }`}
+              >
+                {i + 1}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#dce8e3] bg-white text-[#0d4a38] disabled:opacity-30"
+            >
+              ›
+            </button>
+          </div>
         )}
       </section>
     </DeliveryPageLayout>

--- a/frontend/src/pages/delivery/DeliveryDashboard.jsx
+++ b/frontend/src/pages/delivery/DeliveryDashboard.jsx
@@ -47,7 +47,7 @@ export default function DeliveryDashboard() {
         </p>
       </section>
 
-      <section className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <section className="mt-4 grid grid-cols-2 gap-3 xl:grid-cols-4">
         <Link to="/delivery/orders/current" className="rounded-3xl bg-[#a7ecc6] p-5 text-[#1b5e45] shadow-sm transition hover:brightness-[0.98]">
           <FiTruck size={24} />
           <p className="mt-4 text-xs font-medium tracking-[0.08em]">Current Orders</p>

--- a/frontend/src/pages/delivery/DeliveryOrderHistoryPage.jsx
+++ b/frontend/src/pages/delivery/DeliveryOrderHistoryPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 
@@ -16,28 +16,35 @@ export default function DeliveryOrderHistoryPage() {
   const { historyOrders, loading, error, refreshOrders } = useDeliveryOrders();
   const [searchValue, setSearchValue] = useState('');
   const [statusFilter, setStatusFilter] = useState('ALL');
+  const [sortDir, setSortDir] = useState('desc');
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 8;
 
   const filteredOrders = useMemo(() => {
-    const normalizedSearch = searchValue.trim().toLowerCase();
-
+    const q = searchValue.trim().toLowerCase();
     return historyOrders.filter((order) => {
-      if (!normalizedSearch) return true;
-      const matchesSearch = (
-        String(order.orderId).includes(normalizedSearch) ||
-        String(order.customerName || '').toLowerCase().includes(normalizedSearch)
+      if (!q) return true;
+      return (
+        String(order.orderId).includes(q) ||
+        String(order.customerName || '').toLowerCase().includes(q)
       );
-
-      return matchesSearch;
     });
   }, [historyOrders, searchValue]);
 
   const statusFilteredOrders = useMemo(() => {
-    if (statusFilter === 'ALL') {
-      return filteredOrders;
-    }
+    let result = statusFilter === 'ALL'
+      ? filteredOrders
+      : filteredOrders.filter((order) => String(order?.status || '').toUpperCase() === statusFilter);
+    result = [...result].sort((a, b) =>
+      sortDir === 'desc' ? b.orderId - a.orderId : a.orderId - b.orderId,
+    );
+    return result;
+  }, [filteredOrders, statusFilter, sortDir]);
 
-    return filteredOrders.filter((order) => String(order?.status || '').toUpperCase() === statusFilter);
-  }, [filteredOrders, statusFilter]);
+  useEffect(() => { setPage(0); }, [searchValue, statusFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(statusFilteredOrders.length / PAGE_SIZE));
+  const pagedOrders = statusFilteredOrders.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   const handleRefresh = async () => {
     await refreshOrders();
@@ -58,35 +65,42 @@ export default function DeliveryOrderHistoryPage() {
       onLogout={handleLogout}
     >
       <section className="rounded-3xl border border-[#e4ebe8] bg-white p-4 shadow-sm sm:p-6">
-        <div className="grid grid-cols-1 gap-2">
-          <input
-            type="text"
-            value={searchValue}
-            onChange={(event) => setSearchValue(event.target.value)}
-            placeholder="Search by order ID or customer"
-            className="h-14 w-full rounded-2xl border border-[#d6dfdb] bg-[#eef2f0] px-5 text-base text-[#214338] outline-none transition focus:border-[#9ad3b7] focus:bg-white"
-          />
-        </div>
+        <input
+          type="text"
+          value={searchValue}
+          onChange={(event) => setSearchValue(event.target.value)}
+          placeholder="Search by order ID or customer"
+          className="h-14 w-full rounded-2xl border border-[#d6dfdb] bg-[#eef2f0] px-5 text-base text-[#214338] outline-none transition focus:border-[#9ad3b7] focus:bg-white"
+        />
 
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          {[['ALL', 'All'], ['DELIVERED', 'Delivered'], ['RETURNED', 'Returned'], ['CANCELLED', 'Cancelled']].map(([value, label]) => {
-            const active = statusFilter === value;
-
-            return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setStatusFilter(value)}
-                className={`rounded-full px-4 py-2 text-sm font-medium transition ${
-                  active
-                    ? 'bg-[#01412d] text-white'
-                    : 'bg-[#e6ebe8] text-[#4f5a56] hover:bg-[#dfe6e2]'
-                }`}
-              >
-                {label}
-              </button>
-            );
-          })}
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {[['ALL', 'All'], ['DELIVERED', 'Delivered'], ['RETURNED', 'Returned'], ['CANCELLED', 'Cancelled']].map(([value, label]) => {
+              const active = statusFilter === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setStatusFilter(value)}
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                    active
+                      ? 'bg-[#01412d] text-white'
+                      : 'bg-[#e6ebe8] text-[#4f5a56] hover:bg-[#dfe6e2]'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <select
+            value={sortDir}
+            onChange={(e) => { setSortDir(e.target.value); setPage(0); }}
+            className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+          >
+            <option value="desc">Newest first</option>
+            <option value="asc">Oldest first</option>
+          </select>
         </div>
 
         {loading && <p className="mt-4 text-sm text-slate-500">Loading history...</p>}
@@ -94,12 +108,14 @@ export default function DeliveryOrderHistoryPage() {
         {!loading && error === 'failed' && <p className="mt-4 text-sm text-slate-700">Failed to load history. Please refresh.</p>}
 
         {!loading && !error && statusFilteredOrders.length === 0 && (
-          <p className="mt-4 text-sm text-slate-500">No history orders match your filters.</p>
+          <p className="mt-4 text-sm text-slate-500">
+            {historyOrders.length === 0 ? 'No delivery history yet.' : 'No history orders match your filters.'}
+          </p>
         )}
 
         {!loading && !error && statusFilteredOrders.length > 0 && (
           <ul className="mt-4 space-y-3">
-            {statusFilteredOrders.map((delivery) => (
+            {pagedOrders.map((delivery) => (
               <li key={delivery.orderId}>
                 <DeliveryOrderCard
                   delivery={delivery}
@@ -109,6 +125,41 @@ export default function DeliveryOrderHistoryPage() {
               </li>
             ))}
           </ul>
+        )}
+
+        {!loading && !error && totalPages > 1 && (
+          <div className="mt-5 flex items-center justify-center gap-1">
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#dce8e3] bg-white text-[#0d4a38] disabled:opacity-30"
+            >
+              ‹
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setPage(i)}
+                className={`flex h-10 min-w-10 items-center justify-center rounded-xl border px-2 text-sm font-semibold transition ${
+                  i === page
+                    ? 'border-[#01412d] bg-[#01412d] text-white'
+                    : 'border-[#dce8e3] bg-white text-[#4a6259] hover:bg-[#f1f6f4]'
+                }`}
+              >
+                {i + 1}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#dce8e3] bg-white text-[#0d4a38] disabled:opacity-30"
+            >
+              ›
+            </button>
+          </div>
         )}
       </section>
     </DeliveryPageLayout>

--- a/frontend/src/pages/delivery/DeliveryProfilePage.jsx
+++ b/frontend/src/pages/delivery/DeliveryProfilePage.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
-import { FiUser } from 'react-icons/fi';
+import { FiCheckCircle, FiPackage, FiRefreshCcw, FiTruck, FiUser } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../../context/AuthContext';
@@ -145,23 +145,21 @@ export default function DeliveryProfilePage() {
         </div>
       </section>
 
-      <section className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded-3xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
-          <p className="text-xs font-medium tracking-[0.08em] text-[#5f6d68]">Assigned Orders</p>
-          <p className="mt-2 text-3xl font-semibold leading-none text-[#0d3f31] sm:text-4xl">{summary.assignedOrderCount}</p>
-        </div>
-        <div className="rounded-3xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
-          <p className="text-xs font-medium tracking-[0.08em] text-[#5f6d68]">Out For Delivery</p>
-          <p className="mt-2 text-3xl font-semibold leading-none text-[#0d3f31] sm:text-4xl">{summary.outForDeliveryCount}</p>
-        </div>
-        <div className="rounded-3xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
-          <p className="text-xs font-medium tracking-[0.08em] text-[#5f6d68]">Completed Orders</p>
-          <p className="mt-2 text-3xl font-semibold leading-none text-[#0d3f31] sm:text-4xl">{summary.completedOrderCount}</p>
-        </div>
-        <div className="rounded-3xl border border-[#e4ebe8] bg-white p-5 shadow-sm">
-          <p className="text-xs font-medium tracking-[0.08em] text-[#5f6d68]">Returned Orders</p>
-          <p className="mt-2 text-3xl font-semibold leading-none text-[#0d3f31] sm:text-4xl">{summary.returnedCount}</p>
-        </div>
+      <section className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {[
+          { label: 'Assigned', value: summary.assignedOrderCount, icon: <FiPackage size={18} />, bg: 'bg-[#fef3c7]', color: 'text-[#92400e]' },
+          { label: 'Out For Delivery', value: summary.outForDeliveryCount, icon: <FiTruck size={18} />, bg: 'bg-[#dbeafe]', color: 'text-[#1d4ed8]' },
+          { label: 'Completed', value: summary.completedOrderCount, icon: <FiCheckCircle size={18} />, bg: 'bg-[#d1fae5]', color: 'text-[#065f46]' },
+          { label: 'Returned', value: summary.returnedCount, icon: <FiRefreshCcw size={18} />, bg: 'bg-[#fee2e2]', color: 'text-[#991b1b]' },
+        ].map(({ label, value, icon, bg, color }) => (
+          <div key={label} className="rounded-3xl border border-[#e4ebe8] bg-white p-4 shadow-sm">
+            <div className={`inline-flex h-9 w-9 items-center justify-center rounded-xl ${bg} ${color}`}>
+              {icon}
+            </div>
+            <p className="mt-3 text-[11px] font-medium leading-tight tracking-[0.07em] text-[#5f6d68]">{label}</p>
+            <p className="mt-1 text-3xl font-semibold leading-none text-[#0d3f31]">{value}</p>
+          </div>
+        ))}
       </section>
 
       <section className="mt-4 rounded-3xl border border-[#e4ebe8] bg-white p-4 shadow-sm sm:p-6">

--- a/frontend/src/pages/products/ProductListingPage.jsx
+++ b/frontend/src/pages/products/ProductListingPage.jsx
@@ -82,7 +82,7 @@ export default function ProductListingPage() {
         setLoading(true);
         setError(null);
 
-        return getProducts({ search: committedSearch, category, sortBy, page, size: 12 });
+        return getProducts({ search: committedSearch, category, sortBy, page, size: 8 });
       })
       .then((data) => {
         if (!cancelled && data) {
@@ -233,23 +233,53 @@ export default function ProductListingPage() {
 
         {/* ── Pagination ── */}
         {result && result.totalPages > 1 && (
-          <div className="mt-8 flex items-center justify-center gap-2">
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-2">
+            {/* Prev */}
             <button
               onClick={() => handlePageChange(Math.max(0, page - 1))}
               disabled={page === 0}
               className="rounded-lg border border-[#ccd7d1] bg-white px-4 py-2 text-sm text-[#2a4d3f] transition-colors hover:bg-[#f3f7f5] disabled:opacity-40"
             >
-              Prev
+              ← Prev
             </button>
-            <span className="rounded-full bg-[#0f5b3f] px-3 py-1 text-xs font-semibold text-white">
-              Page {page + 1} of {result.totalPages}
-            </span>
+
+            {/* Numbered buttons — show up to 5 around the current page */}
+            {Array.from({ length: result.totalPages }, (_, i) => i)
+              .filter((i) => {
+                if (result.totalPages <= 7) return true;
+                if (i === 0 || i === result.totalPages - 1) return true;
+                return Math.abs(i - page) <= 2;
+              })
+              .reduce((acc, i, idx, arr) => {
+                if (idx > 0 && i - arr[idx - 1] > 1) acc.push('...');
+                acc.push(i);
+                return acc;
+              }, [])
+              .map((item, idx) =>
+                item === '...' ? (
+                  <span key={`ellipsis-${idx}`} className="px-1 text-sm text-[#8fa89f]">&hellip;</span>
+                ) : (
+                  <button
+                    key={item}
+                    onClick={() => handlePageChange(item)}
+                    className={`min-w-9 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                      item === page
+                        ? 'border-[#0d4a38] bg-[#0d4a38] text-white'
+                        : 'border-[#ccd7d1] bg-white text-[#2a4d3f] hover:bg-[#f3f7f5]'
+                    }`}
+                  >
+                    {item + 1}
+                  </button>
+                ),
+              )}
+
+            {/* Next */}
             <button
               onClick={() => handlePageChange(Math.min(result.totalPages - 1, page + 1))}
               disabled={page >= result.totalPages - 1}
               className="rounded-lg border border-[#ccd7d1] bg-white px-4 py-2 text-sm text-[#2a4d3f] transition-colors hover:bg-[#f3f7f5] disabled:opacity-40"
             >
-              Next
+              Next →
             </button>
           </div>
         )}

--- a/frontend/src/pages/supplier/SupplierDashboard.jsx
+++ b/frontend/src/pages/supplier/SupplierDashboard.jsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
-import { FiMoreVertical, FiPlus } from 'react-icons/fi';
+import { FiPlus, FiSearch, FiTag, FiTrendingUp, FiAlertCircle } from 'react-icons/fi';
 import { getSupplierProducts, getSupplierDashboard } from '../../services/supplierService';
 import { formatPrice } from '../../utils/priceUtils';
 import RequestProductModal from '../../components/supplier/RequestProductModal';
@@ -18,8 +18,12 @@ export default function SupplierDashboard() {
   const [dashboardData, setDashboardData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [currentPage, setCurrentPage] = useState(0);
-  const pageSize = 6;
+  const [search, setSearch] = useState('');
+  const [filterStatus, setFilterStatus] = useState('all');
+  const [sortField, setSortField] = useState('name');
+  const [sortDir, setSortDir] = useState('asc');
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 8;
 
   const loadSupplierData = async () => {
     setLoading(true);
@@ -30,7 +34,7 @@ export default function SupplierDashboard() {
       ]);
       setProducts(productData);
       setDashboardData(dashboardRes);
-      setCurrentPage(0);
+      setPage(0);
     } catch {
       toast.error('Failed to load supplier dashboard data');
     } finally {
@@ -49,17 +53,43 @@ export default function SupplierDashboard() {
   };
 
   const totalBrands = dashboardData?.brandNames?.length || 0;
-  const totalPages = Math.max(1, Math.ceil(products.length / pageSize));
-  const productsPreview = products.slice(currentPage * pageSize, (currentPage + 1) * pageSize);
 
-  const handleProductAction = async (product) => {
-    try {
-      await navigator.clipboard.writeText(String(product.id));
-      toast.success(`Product ID copied: ${product.id}`);
-    } catch {
-      toast.success(`${product.name} (${product.id})`);
-    }
+  useEffect(() => { setPage(0); }, [search, filterStatus]);
+
+  const handleSort = (field) => {
+    if (sortField === field) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortField(field); setSortDir('asc'); }
+    setPage(0);
   };
+
+  const filteredProducts = useMemo(() => {
+    let result = [...products];
+    const q = search.toLowerCase();
+    if (q) {
+      result = result.filter(
+        (p) =>
+          (p.name || '').toLowerCase().includes(q) ||
+          (p.brandName || '').toLowerCase().includes(q) ||
+          (p.category || '').toLowerCase().includes(q),
+      );
+    }
+    if (filterStatus !== 'all') {
+      result = result.filter((p) => p.approvalStatus === filterStatus);
+    }
+    result.sort((a, b) => {
+      let av, bv;
+      if (sortField === 'stock') { av = a.stockQuantity ?? 0; bv = b.stockQuantity ?? 0; return sortDir === 'asc' ? av - bv : bv - av; }
+      if (sortField === 'price') { av = a.price ?? 0; bv = b.price ?? 0; return sortDir === 'asc' ? av - bv : bv - av; }
+      av = sortField === 'brand' ? (a.brandName || '') : sortField === 'category' ? (a.category || '') : (a.name || '');
+      bv = sortField === 'brand' ? (b.brandName || '') : sortField === 'category' ? (b.category || '') : (b.name || '');
+      const cmp = av.localeCompare(bv);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return result;
+  }, [products, search, filterStatus, sortField, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredProducts.length / PAGE_SIZE));
+  const paged = filteredProducts.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   return (
     <SupplierLayout
@@ -76,24 +106,27 @@ export default function SupplierDashboard() {
         </div>
       ) : (
         <>
-          <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <section className="grid grid-cols-2 gap-3 lg:grid-cols-3">
             <MetricCard
               label="Your Brands"
               value={String(totalBrands)}
               chipLabel="Active Portfolios"
               chipStyle="bg-[#eaf5ef] text-[#1c634b]"
+              icon={FiTag}
             />
             <MetricCard
               label="Total Sales"
               value={formatPrice(dashboardData?.totalSales ?? 0)}
               chipLabel="This Month"
               chipStyle="bg-[#eaf5ef] text-[#1c634b]"
+              icon={FiTrendingUp}
             />
             <MetricCard
               label="Pending Restocks"
               value={String(dashboardData?.pendingRestocks || 0)}
               chipLabel="Immediate Attention"
               chipStyle="bg-[#fdecee] text-[#c23939]"
+              icon={FiAlertCircle}
             />
           </section>
 
@@ -110,6 +143,30 @@ export default function SupplierDashboard() {
               </button>
             </div>
 
+            <div className="mb-4 flex flex-wrap items-center gap-2">
+              <div className="relative min-w-48 flex-1">
+                <FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8fa89f]" />
+                <input
+                  type="search"
+                  placeholder="Search by name, brand or category..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="h-9 w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] pl-9 pr-3 text-sm text-[#5f7770] focus:outline-none"
+                />
+              </div>
+              <select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value)}
+                className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+              >
+                <option value="all">All statuses</option>
+                <option value="APPROVED">Approved</option>
+                <option value="PENDING">Pending</option>
+                <option value="REJECTED">Rejected</option>
+              </select>
+              <span className="text-xs text-[#6f817b]">{filteredProducts.length} product{filteredProducts.length !== 1 ? 's' : ''}</span>
+            </div>
+
             <RequestProductModal
               isOpen={isModalOpen}
               onClose={() => setIsModalOpen(false)}
@@ -122,42 +179,44 @@ export default function SupplierDashboard() {
               <p className="rounded-xl border border-[#e4ebe8] bg-[#f8fbf9] p-6 text-sm text-[#6f817b]">
                 No products available for your assigned brand(s).
               </p>
+            ) : filteredProducts.length === 0 ? (
+              <p className="rounded-xl border border-[#e4ebe8] bg-[#f8fbf9] p-6 text-sm text-[#6f817b]">
+                No products match your search or filter.
+              </p>
             ) : (
               <>
                 <div className="hidden overflow-hidden rounded-xl border border-[#e4ebe8] md:block">
                   <table className="w-full text-sm">
                     <thead className="bg-[#f7f9f8] text-[11px] uppercase tracking-[0.08em] text-[#667872]">
                       <tr>
-                        <th className={th}>Product</th>
-                        <th className={th}>Brand</th>
-                        <th className={th}>Category</th>
-                        <th className={th}>Price (Rs.)</th>
-                        <th className={th}>Stock</th>
+                        <SortableHeader label="Product" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                        <SortableHeader label="Brand" field="brand" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                        <SortableHeader label="Category" field="category" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                        <SortableHeader label="Price (Rs.)" field="price" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                        <SortableHeader label="Stock" field="stock" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
                         <th className={th}>Approval Status</th>
-                        <th className={th}>Actions</th>
+
                       </tr>
                     </thead>
                     <tbody>
-                      {productsPreview.map((product) => (
+                      {paged.map((product) => (
                         <tr key={product.id} className="border-t border-[#edf2f0] text-[#29453c]">
                           <td className={`${td} font-semibold`}>{product.name}</td>
                           <td className={td}>{product.brandName || '-'} </td>
                           <td className={td}>{product.category || '-'}</td>
                           <td className={td}>{formatPrice(product.price, product.unit)}</td>
-                          <td className={td}>{product.stockQuantity}</td>
+                          <td className={td}>
+                            <span className={product.reorderThreshold != null && product.stockQuantity <= product.reorderThreshold ? 'font-semibold text-red-600' : ''}>
+                              {product.stockQuantity}
+                            </span>
+                            {product.reorderThreshold != null && product.stockQuantity <= product.reorderThreshold && (
+                              <span className="ml-2 inline-flex rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-700">Low Stock</span>
+                            )}
+                          </td>
                           <td className={td}>
                             <ApprovalBadge status={product.approvalStatus} />
                           </td>
-                          <td className={td}>
-                            <button
-                              type="button"
-                              aria-label={`More actions for ${product.name}`}
-                              onClick={() => handleProductAction(product)}
-                              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[#5d726b] transition hover:bg-[#f0f4f2] hover:text-[#173b31]"
-                            >
-                              <FiMoreVertical className="h-4 w-4" />
-                            </button>
-                          </td>
+
                         </tr>
                       ))}
                     </tbody>
@@ -165,7 +224,7 @@ export default function SupplierDashboard() {
                 </div>
 
                 <div className="space-y-3 md:hidden">
-                  {productsPreview.map((product) => (
+                  {paged.map((product) => (
                     <article
                       key={product.id}
                       className="rounded-xl border border-[#e4ebe8] bg-white p-4"
@@ -188,35 +247,27 @@ export default function SupplierDashboard() {
                         </div>
                         <div>
                           <dt className="text-xs uppercase tracking-wide text-[#6f817b]">Stock</dt>
-                          <dd>{product.stockQuantity}</dd>
+                          <dd className="flex items-center gap-2">
+                            <span className={product.reorderThreshold != null && product.stockQuantity <= product.reorderThreshold ? 'font-semibold text-red-600' : ''}>
+                              {product.stockQuantity}
+                            </span>
+                            {product.reorderThreshold != null && product.stockQuantity <= product.reorderThreshold && (
+                              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-700">Low Stock</span>
+                            )}
+                          </dd>
                         </div>
                       </dl>
                     </article>
                   ))}
                 </div>
 
-                <div className="mt-4 flex items-center justify-between text-xs text-[#6f817b] md:text-sm">
-                  <span>
-                    Showing {productsPreview.length} of {products.length} products
-                    {' '}({currentPage + 1}/{totalPages})
+                <div className="mt-4 flex items-center justify-between border-t border-[#edf2f0] pt-4">
+                  <span className="text-xs text-[#6f817b]">
+                    Page {page + 1} of {totalPages} &middot; {filteredProducts.length} product{filteredProducts.length !== 1 ? 's' : ''}
                   </span>
-                  <div className="flex items-center gap-2 text-[#173b31]">
-                    <button
-                      type="button"
-                      disabled={currentPage === 0}
-                      onClick={() => setCurrentPage((prev) => Math.max(0, prev - 1))}
-                      className="rounded-md border border-[#dbe4e0] bg-white px-3 py-1.5 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      Previous
-                    </button>
-                    <button
-                      type="button"
-                      disabled={currentPage >= totalPages - 1}
-                      onClick={() => setCurrentPage((prev) => Math.min(totalPages - 1, prev + 1))}
-                      className="rounded-md bg-[#0d4a38] px-3 py-1.5 text-white disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      Next
-                    </button>
+                  <div className="flex gap-2">
+                    <button type="button" disabled={page === 0} onClick={() => setPage((p) => Math.max(0, p - 1))} className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40">Prev</button>
+                    <button type="button" disabled={page >= totalPages - 1} onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} className="rounded-lg bg-[#0d4a38] px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40">Next</button>
                   </div>
                 </div>
               </>
@@ -229,9 +280,25 @@ export default function SupplierDashboard() {
   );
 }
 
-function MetricCard({ label, value, chipLabel, chipStyle }) {
+function SortableHeader({ label, field, sortField, sortDir, onSort, className }) {
+  const active = sortField === field;
+  return (
+    <th className={className}>
+      <button onClick={() => onSort(field)} className="inline-flex items-center gap-1 font-semibold hover:text-[#0d4a38]">
+        {label}
+        <span className="flex flex-col text-[8px] leading-none">
+          <span className={active && sortDir === 'asc' ? 'text-[#0d4a38]' : 'opacity-40'}>▲</span>
+          <span className={active && sortDir === 'desc' ? 'text-[#0d4a38]' : 'opacity-40'}>▼</span>
+        </span>
+      </button>
+    </th>
+  );
+}
+
+function MetricCard({ label, value, chipLabel, chipStyle, icon: Icon }) {
   return (
     <article className="rounded-2xl border border-[#e4ebe8] bg-white p-5">
+      {Icon && <Icon className="mb-2 h-5 w-5 text-[#6f817b]" />}
       <p className="text-xs font-medium uppercase tracking-[0.08em] text-[#6f817b]">{label}</p>
       <p className="mt-2 text-3xl font-extrabold tracking-tight text-[#163a2f]">{value}</p>
       <span className={`mt-3 inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${chipStyle}`}>

--- a/frontend/src/pages/supplier/SupplierPurchaseOrdersPage.jsx
+++ b/frontend/src/pages/supplier/SupplierPurchaseOrdersPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import { FiCheck, FiDownload, FiSend, FiX } from 'react-icons/fi';
+import { FiCheck, FiDownload, FiSearch, FiSend, FiX } from 'react-icons/fi';
 import useSupplierPurchaseOrders from '../../hooks/useSupplierPurchaseOrders';
 import UpdatePurchaseOrderStatusModal from '../../components/supplier/UpdatePurchaseOrderStatusModal';
 import toast from 'react-hot-toast';
@@ -22,10 +22,23 @@ export default function SupplierPurchaseOrdersPage() {
   const [noticeOrderId, setNoticeOrderId] = useState(null);
   const [noticeText, setNoticeText] = useState('');
   const [statusFilter, setStatusFilter] = useState('ALL');
+  const [search, setSearch] = useState('');
+  const [sortField, setSortField] = useState('id');
+  const [sortDir, setSortDir] = useState('desc');
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 8;
 
   useEffect(() => {
     fetchOrders();
   }, [fetchOrders]);
+
+  useEffect(() => { setPage(0); }, [statusFilter, search]);
+
+  const handleSort = (field) => {
+    if (sortField === field) setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortField(field); setSortDir('asc'); }
+    setPage(0);
+  };
 
   const handleLogout = () => {
     logout();
@@ -82,11 +95,28 @@ export default function SupplierPurchaseOrdersPage() {
   };
 
   const filteredOrders = useMemo(() => {
-    if (statusFilter === 'ALL') {
-      return orders;
+    let result = statusFilter === 'ALL' ? [...orders] : orders.filter((o) => o.status === statusFilter);
+    const q = search.toLowerCase();
+    if (q) {
+      result = result.filter(
+        (o) =>
+          `PO-${o.id}`.toLowerCase().includes(q) ||
+          (o.brandName || '').toLowerCase().includes(q) ||
+          (o.items || []).some((item) => item.productName?.toLowerCase().includes(q)),
+      );
     }
-    return orders.filter((order) => order.status === statusFilter);
-  }, [orders, statusFilter]);
+    result.sort((a, b) => {
+      if (sortField === 'id') return sortDir === 'asc' ? a.id - b.id : b.id - a.id;
+      const av = sortField === 'brand' ? (a.brandName || '') : (a.status || '');
+      const bv = sortField === 'brand' ? (b.brandName || '') : (b.status || '');
+      const cmp = av.localeCompare(bv);
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return result;
+  }, [orders, statusFilter, search, sortField, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredOrders.length / PAGE_SIZE));
+  const pagedOrders = filteredOrders.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
   const activeOrders = orders.filter((order) => !['COMPLETED', 'CANCELLED'].includes(order.status)).length;
   const pendingActions = orders.filter((order) => order.status === 'PENDING').length;
@@ -201,9 +231,37 @@ export default function SupplierPurchaseOrdersPage() {
               <p className="text-sm text-[#6f817b]">Logged in as {user?.name}</p>
             </div>
 
+            <div className="mb-4 flex flex-wrap items-center gap-2">
+              <div className="relative min-w-48 flex-1">
+                <FiSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8fa89f]" />
+                <input
+                  type="search"
+                  placeholder="Search by PO#, brand or item..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="h-9 w-full rounded-xl border border-[#dce8e3] bg-[#f4f7f6] pl-9 pr-3 text-sm text-[#5f7770] focus:outline-none"
+                />
+              </div>
+              <select
+                value={`${sortField}:${sortDir}`}
+                onChange={(e) => {
+                  const [f, d] = e.target.value.split(':');
+                  setSortField(f); setSortDir(d); setPage(0);
+                }}
+                className="h-9 rounded-xl border border-[#dce8e3] bg-[#f4f7f6] px-3 text-sm text-[#5f7770] focus:outline-none"
+              >
+                <option value="id:desc">Newest first</option>
+                <option value="id:asc">Oldest first</option>
+                <option value="brand:asc">Brand A–Z</option>
+                <option value="brand:desc">Brand Z–A</option>
+                <option value="status:asc">Status A–Z</option>
+              </select>
+              <span className="text-xs text-[#6f817b]">{filteredOrders.length} order{filteredOrders.length !== 1 ? 's' : ''}</span>
+            </div>
+
             {filteredOrders.length === 0 ? (
               <div className="rounded-xl border border-[#e4ebe8] bg-[#f8fbf9] p-8 text-center text-sm text-[#6f817b]">
-                No purchase orders found for your assigned brands.
+                {orders.length === 0 ? 'No purchase orders found for your assigned brands.' : 'No orders match your search or filter.'}
               </div>
             ) : (
               <>
@@ -211,16 +269,16 @@ export default function SupplierPurchaseOrdersPage() {
                   <table className="w-full text-sm">
                     <thead className="bg-[#f7f9f8] text-[11px] uppercase tracking-[0.08em] text-[#667872]">
                       <tr>
-                        <th className={th}>Order/PO #</th>
-                        <th className={th}>Brand</th>
+                        <SortableHeader label="Order/PO #" field="id" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
+                        <SortableHeader label="Brand" field="brand" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
                         <th className={th}>Items</th>
                         <th className={th}>Delivery ETA</th>
-                        <th className={th}>Status</th>
+                        <SortableHeader label="Status" field="status" sortField={sortField} sortDir={sortDir} onSort={handleSort} className={th} />
                         <th className={th}>Actions</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredOrders.map((order) => (
+                      {pagedOrders.map((order) => (
                         <tr key={order.id} className="border-t border-[#edf2f0] align-top text-[#26443a]">
                           <td className={`${td} font-semibold`}>PO-{order.id}</td>
                           <td className={td}>{order.brandName || 'Unknown'}</td>
@@ -268,7 +326,7 @@ export default function SupplierPurchaseOrdersPage() {
                 </div>
 
                 <div className="space-y-3 md:hidden">
-                  {filteredOrders.map((order) => (
+                  {pagedOrders.map((order) => (
                     <article key={order.id} className="rounded-xl border border-[#e4ebe8] bg-white p-4">
                       <div className="flex items-start justify-between gap-3">
                         <div>
@@ -307,6 +365,17 @@ export default function SupplierPurchaseOrdersPage() {
                     </article>
                   ))}
                 </div>
+                {totalPages > 1 && (
+                  <div className="mt-4 flex items-center justify-between border-t border-[#edf2f0] pt-4">
+                    <span className="text-xs text-[#6f817b]">
+                      Page {page + 1} of {totalPages} &middot; {filteredOrders.length} order{filteredOrders.length !== 1 ? 's' : ''}
+                    </span>
+                    <div className="flex gap-2">
+                      <button onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0} className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40">Prev</button>
+                      <button onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))} disabled={page >= totalPages - 1} className="rounded-lg border border-[#dce8e3] bg-white px-3 py-1.5 text-xs font-medium text-[#5f7770] disabled:opacity-40">Next</button>
+                    </div>
+                  </div>
+                )}
               </>
             )}
           </section>
@@ -353,6 +422,21 @@ export default function SupplierPurchaseOrdersPage() {
         onUpdateSuccess={() => fetchOrders()}
       />
     </SupplierLayout>
+  );
+}
+
+function SortableHeader({ label, field, sortField, sortDir, onSort, className }) {
+  const active = sortField === field;
+  return (
+    <th className={className}>
+      <button onClick={() => onSort(field)} className="inline-flex items-center gap-1 font-semibold hover:text-[#0d4a38]">
+        {label}
+        <span className="flex flex-col text-[8px] leading-none">
+          <span className={active && sortDir === 'asc' ? 'text-[#0d4a38]' : 'opacity-40'}>▲</span>
+          <span className={active && sortDir === 'desc' ? 'text-[#0d4a38]' : 'opacity-40'}>▼</span>
+        </span>
+      </button>
+    </th>
   );
 }
 


### PR DESCRIPTION
### Summary
Replaces placeholder/non-functional UI elements with fully working search, filtering, sorting, and pagination across the Admin, Supplier, and Delivery personnel sections. Removes hardcoded mock data sections and dead action buttons that were left over from early development.

---

### Changes by area

**Admin — Products & Inventory**
- Removed non-functional Filters button from `AdminProductsPage` and `AdminInventoryPage`

**Admin — Suppliers & Brands**
- `AdminSuppliersPage`: search by name/email/brand, status filter, sortable headers (Name / Email / Status), 10/page pagination
- `AdminBrandsPage`: search by name/code, status filter, sortable headers (Name / Code / Status), 10/page pagination

**Admin — Purchase Orders**
- Removed non-functional Filters button
- Removed hardcoded mock sections: Total Outflow, Inventory Replenishment Status, Supplier Attention Required
- Removed non-functional Track action from order rows
- Removed unused `noticedOrders` memo and `ProgressRow` component
- Added search (PO# / brand / item name), sort dropdown, page reset on filter/search change
- Pagination: 4 orders/page with dynamic numbered buttons and correct result count
- Added "Back to Inventory" button in the page header

**Supplier**
- `SupplierPurchaseOrdersPage`: search (PO# / brand / item), sort dropdown, sortable headers (Order / Brand / Status), 8/page pagination
- `SupplierDashboard`: search (name / brand / category), approval status filter, sortable headers (Product / Brand / Category / Price / Stock), pagination upgraded to 8/page

**Delivery Personnel**
- `DeliveryCurrentOrdersPage`: sort dropdown (newest/oldest) on Active Orders, 8/page pagination, page resets on search change
- `DeliveryOrderHistoryPage`: sort dropdown alongside status filter pills, 8/page pagination, page resets on search/filter change, fixed filter pills spacing (was cramped against search bar)

**Product Listing**
- Replaced Prev/Next buttons with numbered pagination + ellipsis, reduced page size from 12 → 8

---

### Testing
- All modified files pass lint with no errors
- Pagination, search, and sort state resets correctly on filter changes across all pages
- Empty states distinguish "no data at all" from "no results for current search/filter"